### PR TITLE
feat: CliBackend + OpenAPI 3.1 generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.remember/logs/autonomous
+.worktrees/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,21 @@
+# mcpipe
+
+## Build & Run
+- `cargo build --release` — binary at `./target/release/mcpipe`
+- `cargo clippy && cargo test` — required before commit
+
+## Common Commands
+- `./target/release/mcpipe --mcp <SSE_URL> --list` — discover tools from an MCP server
+- `./target/release/mcpipe --mcp <SSE_URL> <tool-name> --<param> <value>` — execute a tool
+- Pieces MCP SSE endpoint: `http://localhost:39300/model_context_protocol/2024-11-05/sse`
+
+## Architecture
+- `src/backend/mcp.rs` — stdio + HTTP/SSE transports; `StdioSession` and `HttpSession`
+- `src/backend/openapi.rs`, `src/backend/graphql.rs` — other backend types
+- `src/domain.rs` — `Backend` trait (hexagonal port), `CommandDef`, `BackendError`
+- `src/main.rs` — dynamic clap CLI built from discovered `CommandDef`s at runtime
+
+## Quirks
+- `--list` output includes descriptions; to extract tool names: `grep -E '^[a-z][a-z0-9-]+\s' | awk '{print $1}'`
+- Pieces MCP exposes ~35 real tools (full-text search, vector search, batch snapshot, LTM)
+- `HANDOFF.md` tracks known gaps and remaining work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,4 +18,7 @@
 ## Quirks
 - `--list` output includes descriptions; to extract tool names: `grep -E '^[a-z][a-z0-9-]+\s' | awk '{print $1}'`
 - Pieces MCP exposes ~35 real tools (full-text search, vector search, batch snapshot, LTM)
-- `HANDOFF.md` tracks known gaps and remaining work
+- Integration tests: `cargo test --features integration`
+- Maestro API spec + docs: `maestro-api/maestro-api.openapi.yaml` and `maestro-api/API.md`
+- `HANDOFF.mcpipe.workspace.yaml` tracks open items; sync with
+  `doob handoff sync --file HANDOFF.mcpipe.workspace.yaml`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -965,6 +965,7 @@ dependencies = [
  "clap",
  "dirs",
  "eventsource-client",
+ "futures",
  "hex",
  "json5",
  "reqwest",
@@ -976,6 +977,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,8 @@ sha2 = { version = "0.10", features = [] }
 hex = "0.4"
 eventsource-client = "0.12"
 dirs = "5"
+futures = "0.3.32"
+url = "2.5.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -1,14 +1,15 @@
 project: mcpipe
 id: mcpipe
-updated: 2026-04-03
+updated: 2026-04-04
 branch: main
 state:
   tests: 28 passing (31 with --features integration)
   build: clean
-  notes: All P1 items done. Remaining sentinel suggestions are P3 code quality (no blockers).
+  notes: |
+    Used mcpipe against local + staging Maestro API. OpenAPI spec + API.md written at maestro-api/. AbortHandle Drop impl still missing (sentinel P1 open).
 items:
 - id: mcpipe-6
-  doob_uuid: 50bfb5cf-adbe-4354-84a2-999ee899ff4b
+  doob_uuid: a8aefce8-b10e-4960-bac3-137e6ad10f5d
   name: auth-headers-field-rename
   priority: P1
   status: done
@@ -17,7 +18,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-7
-  doob_uuid: 4c651e66-5732-4480-a368-86fe95e7b1e5
+  doob_uuid: bfa8abff-beac-42db-a4a6-5473603f4593
   name: stream-task-abort-handle
   priority: P1
   status: done
@@ -26,7 +27,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-1
-  doob_uuid: 5ca4ada7-cee7-42a6-93d8-929d7991b4b7
+  doob_uuid: e75707a2-cab5-42cc-a2f6-d522b88b4bcc
   name: openapi-relative-server-url
   priority: P1
   status: done
@@ -35,7 +36,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-2
-  doob_uuid: aa35815f-d9ac-4613-8be9-6f9400ca088d
+  doob_uuid: 4d50bdaa-f30a-4e1c-ab5a-7d7d307f1205
   name: arbitrary-request-headers
   priority: P1
   status: done
@@ -44,7 +45,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-3
-  doob_uuid: 81c30a98-9d5b-4fc3-933f-8b11fbbfaa25
+  doob_uuid: f6d25648-4dd2-4052-85b7-46a1574ab778
   name: graphql-fields-override
   priority: P2
   status: done
@@ -53,7 +54,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-4
-  doob_uuid: 8140bddc-05d4-479d-933f-ab1012559a32
+  doob_uuid: 86e70cf8-0efe-4984-bb12-d588269d727d
   name: integration-test-feature-gate
   priority: P2
   status: done
@@ -62,7 +63,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-5
-  doob_uuid: 4dfa724a-159c-4dbf-9175-01e4685a77da
+  doob_uuid: cc8755c6-8ee5-4aad-b44c-2353c52af326
   name: list-search-output-polish
   priority: P2
   status: done
@@ -71,7 +72,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-8
-  doob_uuid: 6c3a0444-da01-48b0-a5aa-bc3b71213530
+  doob_uuid: bd582b04-47c9-4b5c-b9e4-8ce38661312f
   name: argv-strip-round-trip-test
   priority: P3
   status: parked
@@ -85,7 +86,7 @@ items:
     type: note
     note: Superseded by conductor task xzo88d4ls8hu6h1lo3ft (same finding, better description).
 - id: mcpipe-9
-  doob_uuid: 83c3e132-e17a-416e-87f5-0c9348b1de53
+  doob_uuid: cf4c35f5-1806-4dcb-b260-e26f47836439
   name: reqwest-client-per-call
   priority: P3
   status: parked
@@ -99,7 +100,7 @@ items:
     type: note
     note: Superseded by conductor task 15poox8e4xlmpxdqu2ot.
 - id: mcpipe-10
-  doob_uuid: b1cef003-0d4e-45cc-836c-fec644cc130a
+  doob_uuid: 6bdc3a43-becb-47be-8e7c-a25421b609d3
   name: header-param-injection
   priority: P3
   status: parked
@@ -113,7 +114,7 @@ items:
     type: note
     note: Superseded by conductor task 1ezidbsqfljp81cki67k.
 - id: mcpipe-11
-  doob_uuid: f36e910f-b83b-4d5a-87d2-1141768f3e25
+  doob_uuid: ea49882b-0887-48ce-adf3-1f05980ac2af
   name: stdio-child-stderr-forwarding
   priority: P3
   status: parked
@@ -126,7 +127,39 @@ items:
   - date: 2026-04-03
     type: note
     note: Superseded by conductor task 2tgau6uz7crk3laphvol.
+- id: mcpipe-12
+  doob_uuid: 6ef6f2b5-645c-4a3d-b374-1777c7ce79af
+  name: abort-handle-drop-impl
+  priority: P1
+  status: open
+  title: Add `impl Drop for HttpSession` calling `self._stream_abort.abort()`
+  description: |
+    AbortHandle is stored on HttpSession but never fired — no Drop impl exists.
+    The SSE background task leaks on every session drop. Fix: add
+    `impl Drop for HttpSession { fn drop(&mut self) { self._stream_abort.abort(); } }`
+  files:
+  - src/backend/mcp.rs
+  extra: []
+- id: mcpipe-13
+  doob_uuid: c4aa5b7b-9245-4647-84c0-15efaf06d957
+  name: maestro-api-openapi-spec
+  priority: P2
+  status: done
+  title: Write OpenAPI spec and API.md for maestro-api
+  description: |
+    OpenAPI spec covering all 25 endpoints at maestro-api/maestro-api.openapi.yaml.
+    API.md documents all endpoints with live response shapes, error codes,
+    session lifecycle, and mcpipe usage examples. Verified against local debug
+    server (port 8090) and staging (api.maestro-staging.toptal.net).
+  files:
+  - maestro-api/maestro-api.openapi.yaml
+  - maestro-api/API.md
+  extra: []
+  completed: 2026-04-04
 log:
+- date: 2026-04-04
+  summary: |
+    Started local maestro-api (port 8090, debug build). Wrote OpenAPI spec (25 endpoints) and API.md. Verified mcpipe against local + staging Maestro API — create-session round-trip confirmed on staging K8s. Discovered AbortHandle Drop impl still missing (mcpipe-12).
 - date: 2026-04-03
   summary: 'mcpipe-6 + mcpipe-7 done: renamed auth_headers → headers throughout McpTransport::Http; replaced _stream_task JoinHandle with AbortHandle (aborted on drop). 28 tests passing.'
   commits:

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -3,78 +3,50 @@ id: mcpipe
 updated: 2026-04-03
 branch: main
 state:
-  tests: "28 passing"
+  tests: "28 passing (31 with --features integration)"
   build: clean
-  notes: HTTP/SSE transport verified against Pieces MCP (~35 tools, execute round-trip confirmed)
+  notes: All handoff items from previous session completed
 
 items:
   - id: mcpipe-1
     name: openapi-relative-server-url
     priority: P1
-    status: open
+    status: done
+    completed: 2026-04-03
     title: Relative `servers[0].url` in OpenAPI specs breaks HTTP requests
-    description: >
-      Specs like petstore use `/api/v3` as servers[0].url. mcpipe uses it literally,
-      failing the HTTP client. Fix: add `--base-url <URL>` global flag; in
-      OpenApiBackend::execute() prefer user-supplied URL. Also auto-resolve relative
-      server URL against the spec's fetch URL (strip path, append relative URL).
-    files:
-      - src/backend/openapi.rs
-      - src/main.rs
 
   - id: mcpipe-2
     name: arbitrary-request-headers
     priority: P1
-    status: open
+    status: done
+    completed: 2026-04-03
     title: Add `--header KEY:VALUE` flag for arbitrary HTTP headers
-    description: >
-      No way to pass arbitrary headers. GitHub API requires `User-Agent: <app>`.
-      Add repeatable `--header KEY:VALUE` to global parser, thread into OpenApiBackend
-      and GraphQlBackend constructors alongside existing auth headers.
-    files:
-      - src/main.rs
-      - src/backend/openapi.rs
-      - src/backend/graphql.rs
 
   - id: mcpipe-3
     name: graphql-fields-override
     priority: P2
-    status: open
+    status: done
+    completed: 2026-04-03
     title: Wire `--fields` override for GraphQL selection sets
-    description: >
-      GraphQlBackend has with_fields_override() but the CLI doesn't expose it per-subcommand.
-      Add `--fields <FIELDS>` as a per-subcommand arg; in execute() check args for
-      a "__fields" key and use it as the selection set string if present.
-    files:
-      - src/cli.rs
-      - src/backend/graphql.rs
 
   - id: mcpipe-4
     name: integration-test-feature-gate
     priority: P2
-    status: open
+    status: done
+    completed: 2026-04-03
     title: Integration tests behind `--features integration` flag
-    description: >
-      Add [features] integration = [] to Cargo.toml. Gate test files with
-      #![cfg(feature = "integration")]. Write at least one test hitting a real
-      MCP server (echo fixture via stdio, or real HTTP endpoint).
-    files:
-      - Cargo.toml
-      - tests/mcp_adapter.rs
 
   - id: mcpipe-5
     name: list-search-output-polish
     priority: P2
-    status: open
+    status: done
+    completed: 2026-04-03
     title: Polish `--list`/`--search` output with aligned columns
-    description: >
-      Currently prints bare command names one per line. Fix: print `name  —  description`
-      aligned in two columns (max name length for padding). --search already filters
-      by substring — add case-insensitive match. Optional: show param count summary.
-    files:
-      - src/main.rs
 
 log:
+  - date: 2026-04-03
+    summary: Completed all 5 open items — relative URL fix, --header flag, --fields per-subcommand, integration test gate, --list output polish
+    commits: [fb4ff92, aca09b0, 64be13b]
   - date: 2026-04-03
     summary: Implemented HTTP/SSE transport (HttpSession); verified against Pieces MCP; created HANDOFF.mcpipe.workspace.yaml
     commits: [d2cebb8, 8ce346c, 996b68a]

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -8,7 +8,7 @@ state:
   notes: All P1 items done. Remaining sentinel suggestions are P3 code quality (no blockers).
 items:
 - id: mcpipe-6
-  doob_uuid: b0cb93d5-1d52-4efa-9daa-7f289752b6d7
+  doob_uuid: 50bfb5cf-adbe-4354-84a2-999ee899ff4b
   name: auth-headers-field-rename
   priority: P1
   status: done
@@ -17,7 +17,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-7
-  doob_uuid: 9304ea17-55a9-48d5-a46a-35d7aad6acd3
+  doob_uuid: 4c651e66-5732-4480-a368-86fe95e7b1e5
   name: stream-task-abort-handle
   priority: P1
   status: done
@@ -26,7 +26,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-1
-  doob_uuid: 6a84b3e5-7b0c-4844-9470-e3ad7c7a9fd7
+  doob_uuid: 5ca4ada7-cee7-42a6-93d8-929d7991b4b7
   name: openapi-relative-server-url
   priority: P1
   status: done
@@ -35,7 +35,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-2
-  doob_uuid: 852b6f11-4495-4c39-a6dd-c5db1470d041
+  doob_uuid: aa35815f-d9ac-4613-8be9-6f9400ca088d
   name: arbitrary-request-headers
   priority: P1
   status: done
@@ -44,7 +44,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-3
-  doob_uuid: 48ecc79e-dc5d-410e-a1e5-0e3e4b7801f7
+  doob_uuid: 81c30a98-9d5b-4fc3-933f-8b11fbbfaa25
   name: graphql-fields-override
   priority: P2
   status: done
@@ -53,7 +53,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-4
-  doob_uuid: 16625076-55c3-48b5-a9c9-b0866be3907c
+  doob_uuid: 8140bddc-05d4-479d-933f-ab1012559a32
   name: integration-test-feature-gate
   priority: P2
   status: done
@@ -62,7 +62,7 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-5
-  doob_uuid: 8805a692-dab2-42a4-9022-ed3ee11821df
+  doob_uuid: 4dfa724a-159c-4dbf-9175-01e4685a77da
   name: list-search-output-polish
   priority: P2
   status: done
@@ -71,49 +71,61 @@ items:
   extra: []
   completed: 2026-04-03
 - id: mcpipe-8
-  doob_uuid: 1b3ea8cc-9af1-499e-9800-cc0080ce0e0b
+  doob_uuid: 6c3a0444-da01-48b0-a5aa-bc3b71213530
   name: argv-strip-round-trip-test
   priority: P3
-  status: open
+  status: parked
   title: Add round-trip test for global-flag argv stripping
   description: |
     Manual argv stripping in main.rs must be kept in sync with build_global_parser by hand. A mismatch silently passes unknown flags into the dynamic subcommand parser. Consider deriving the strip list from the parser or adding a round-trip test.
   files:
   - src/main.rs
-  extra: []
+  extra:
+  - date: 2026-04-03
+    type: note
+    note: Superseded by conductor task xzo88d4ls8hu6h1lo3ft (same finding, better description).
 - id: mcpipe-9
-  doob_uuid: 6f67b66d-7dfd-41dc-b888-b6db8d61e1ef
+  doob_uuid: 83c3e132-e17a-416e-87f5-0c9348b1de53
   name: reqwest-client-per-call
   priority: P3
-  status: open
+  status: parked
   title: Build reqwest::Client once in OpenApiBackend, not per execute call
   description: |
     reqwest::Client::new() on every execute call allocates a new connection pool. Build the client once in from_file/from_json and store it on the struct.
   files:
   - src/backend/openapi.rs
-  extra: []
+  extra:
+  - date: 2026-04-03
+    type: note
+    note: Superseded by conductor task 15poox8e4xlmpxdqu2ot.
 - id: mcpipe-10
-  doob_uuid: 0fc1055a-206d-4e06-970c-46d22e5c5ca2
+  doob_uuid: b1cef003-0d4e-45cc-836c-fec644cc130a
   name: header-param-injection
   priority: P3
-  status: open
+  status: parked
   title: Inject ParamLocation::Header params into outgoing OpenAPI requests
   description: |
     ParamLocation::Header params are parsed from the spec but never injected into outgoing requests. Add a TODO comment so it's not mistaken for intentional behavior.
   files:
   - src/backend/openapi.rs
-  extra: []
+  extra:
+  - date: 2026-04-03
+    type: note
+    note: Superseded by conductor task 1ezidbsqfljp81cki67k.
 - id: mcpipe-11
-  doob_uuid: b89e5dc9-ac8a-4bb5-8a54-48d93fe4d7c2
+  doob_uuid: f36e910f-b83b-4d5a-87d2-1141768f3e25
   name: stdio-child-stderr-forwarding
   priority: P3
-  status: open
+  status: parked
   title: Forward stdio MCP child stderr instead of discarding via Stdio::null()
   description: |
     Child stderr is discarded via Stdio::null(). Stdio server diagnostics are invisible on crash. Consider forwarding to eprintln! via a background reader.
   files:
   - src/backend/mcp.rs
-  extra: []
+  extra:
+  - date: 2026-04-03
+    type: note
+    note: Superseded by conductor task 2tgau6uz7crk3laphvol.
 log:
 - date: 2026-04-03
   summary: 'mcpipe-6 + mcpipe-7 done: renamed auth_headers → headers throughout McpTransport::Http; replaced _stream_task JoinHandle with AbortHandle (aborted on drop). 28 tests passing.'

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -3,69 +3,133 @@ id: mcpipe
 updated: 2026-04-03
 branch: main
 state:
-  tests: "28 passing (31 with --features integration)"
+  tests: 28 passing (31 with --features integration)
   build: clean
-  notes: All handoff items from previous session completed
-
+  notes: All P1 items done. Remaining sentinel suggestions are P3 code quality (no blockers).
 items:
-  - id: mcpipe-6
-    name: auth-headers-field-rename
-    priority: P1
-    status: done
-    completed: 2026-04-03
-    title: "Rename McpTransport::Http `auth_headers` field to `headers`"
-
-  - id: mcpipe-7
-    name: stream-task-abort-handle
-    priority: P1
-    status: done
-    completed: 2026-04-03
-    title: "Add abort handle for detached SSE stream JoinHandle"
-
-  - id: mcpipe-1
-    name: openapi-relative-server-url
-    priority: P1
-    status: done
-    completed: 2026-04-03
-    title: Relative `servers[0].url` in OpenAPI specs breaks HTTP requests
-
-  - id: mcpipe-2
-    name: arbitrary-request-headers
-    priority: P1
-    status: done
-    completed: 2026-04-03
-    title: Add `--header KEY:VALUE` flag for arbitrary HTTP headers
-
-  - id: mcpipe-3
-    name: graphql-fields-override
-    priority: P2
-    status: done
-    completed: 2026-04-03
-    title: Wire `--fields` override for GraphQL selection sets
-
-  - id: mcpipe-4
-    name: integration-test-feature-gate
-    priority: P2
-    status: done
-    completed: 2026-04-03
-    title: Integration tests behind `--features integration` flag
-
-  - id: mcpipe-5
-    name: list-search-output-polish
-    priority: P2
-    status: done
-    completed: 2026-04-03
-    title: Polish `--list`/`--search` output with aligned columns
-
+- id: mcpipe-6
+  doob_uuid: b0cb93d5-1d52-4efa-9daa-7f289752b6d7
+  name: auth-headers-field-rename
+  priority: P1
+  status: done
+  title: Rename McpTransport::Http `auth_headers` field to `headers`
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-7
+  doob_uuid: 9304ea17-55a9-48d5-a46a-35d7aad6acd3
+  name: stream-task-abort-handle
+  priority: P1
+  status: done
+  title: Add abort handle for detached SSE stream JoinHandle
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-1
+  doob_uuid: 6a84b3e5-7b0c-4844-9470-e3ad7c7a9fd7
+  name: openapi-relative-server-url
+  priority: P1
+  status: done
+  title: Relative `servers[0].url` in OpenAPI specs breaks HTTP requests
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-2
+  doob_uuid: 852b6f11-4495-4c39-a6dd-c5db1470d041
+  name: arbitrary-request-headers
+  priority: P1
+  status: done
+  title: Add `--header KEY:VALUE` flag for arbitrary HTTP headers
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-3
+  doob_uuid: 48ecc79e-dc5d-410e-a1e5-0e3e4b7801f7
+  name: graphql-fields-override
+  priority: P2
+  status: done
+  title: Wire `--fields` override for GraphQL selection sets
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-4
+  doob_uuid: 16625076-55c3-48b5-a9c9-b0866be3907c
+  name: integration-test-feature-gate
+  priority: P2
+  status: done
+  title: Integration tests behind `--features integration` flag
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-5
+  doob_uuid: 8805a692-dab2-42a4-9022-ed3ee11821df
+  name: list-search-output-polish
+  priority: P2
+  status: done
+  title: Polish `--list`/`--search` output with aligned columns
+  files: []
+  extra: []
+  completed: 2026-04-03
+- id: mcpipe-8
+  doob_uuid: 1b3ea8cc-9af1-499e-9800-cc0080ce0e0b
+  name: argv-strip-round-trip-test
+  priority: P3
+  status: open
+  title: Add round-trip test for global-flag argv stripping
+  description: |
+    Manual argv stripping in main.rs must be kept in sync with build_global_parser by hand. A mismatch silently passes unknown flags into the dynamic subcommand parser. Consider deriving the strip list from the parser or adding a round-trip test.
+  files:
+  - src/main.rs
+  extra: []
+- id: mcpipe-9
+  doob_uuid: 6f67b66d-7dfd-41dc-b888-b6db8d61e1ef
+  name: reqwest-client-per-call
+  priority: P3
+  status: open
+  title: Build reqwest::Client once in OpenApiBackend, not per execute call
+  description: |
+    reqwest::Client::new() on every execute call allocates a new connection pool. Build the client once in from_file/from_json and store it on the struct.
+  files:
+  - src/backend/openapi.rs
+  extra: []
+- id: mcpipe-10
+  doob_uuid: 0fc1055a-206d-4e06-970c-46d22e5c5ca2
+  name: header-param-injection
+  priority: P3
+  status: open
+  title: Inject ParamLocation::Header params into outgoing OpenAPI requests
+  description: |
+    ParamLocation::Header params are parsed from the spec but never injected into outgoing requests. Add a TODO comment so it's not mistaken for intentional behavior.
+  files:
+  - src/backend/openapi.rs
+  extra: []
+- id: mcpipe-11
+  doob_uuid: b89e5dc9-ac8a-4bb5-8a54-48d93fe4d7c2
+  name: stdio-child-stderr-forwarding
+  priority: P3
+  status: open
+  title: Forward stdio MCP child stderr instead of discarding via Stdio::null()
+  description: |
+    Child stderr is discarded via Stdio::null(). Stdio server diagnostics are invisible on crash. Consider forwarding to eprintln! via a background reader.
+  files:
+  - src/backend/mcp.rs
+  extra: []
 log:
-  - date: 2026-04-03
-    summary: "mcpipe-6 + mcpipe-7 done: renamed auth_headers → headers throughout McpTransport::Http; replaced _stream_task JoinHandle with AbortHandle (aborted on drop). 28 tests passing."
-    commits: [3ae52cc]
-  - date: 2026-04-03
-    summary: "Sentinel review: 2 blocking issues found (auth_headers field rename, detached JoinHandle). 5 suggestions logged."
-  - date: 2026-04-03
-    summary: Completed all 5 open items — relative URL fix, --header flag, --fields per-subcommand, integration test gate, --list output polish
-    commits: [fb4ff92, aca09b0, 64be13b]
-  - date: 2026-04-03
-    summary: Implemented HTTP/SSE transport (HttpSession); verified against Pieces MCP; created HANDOFF.mcpipe.workspace.yaml
-    commits: [d2cebb8, 8ce346c, 996b68a]
+- date: 2026-04-03
+  summary: 'mcpipe-6 + mcpipe-7 done: renamed auth_headers → headers throughout McpTransport::Http; replaced _stream_task JoinHandle with AbortHandle (aborted on drop). 28 tests passing.'
+  commits:
+  - 3ae52cc
+- date: 2026-04-03
+  summary: 'Sentinel review: 2 blocking issues found (auth_headers field rename, detached JoinHandle). 5 suggestions logged.'
+- date: 2026-04-03
+  summary: Completed all 5 open items — relative URL fix, --header flag, --fields per-subcommand, integration test gate, --list output polish
+  commits:
+  - fb4ff92
+  - aca09b0
+  - 64be13b
+- date: 2026-04-03
+  summary: Implemented HTTP/SSE transport (HttpSession); verified against Pieces MCP; created HANDOFF.mcpipe.workspace.yaml
+  commits:
+  - d2cebb8
+  - 8ce346c
+  - 996b68a

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -8,6 +8,20 @@ state:
   notes: All handoff items from previous session completed
 
 items:
+  - id: mcpipe-6
+    name: auth-headers-field-rename
+    priority: P1
+    status: done
+    completed: 2026-04-03
+    title: "Rename McpTransport::Http `auth_headers` field to `headers`"
+
+  - id: mcpipe-7
+    name: stream-task-abort-handle
+    priority: P1
+    status: done
+    completed: 2026-04-03
+    title: "Add abort handle for detached SSE stream JoinHandle"
+
   - id: mcpipe-1
     name: openapi-relative-server-url
     priority: P1
@@ -44,6 +58,11 @@ items:
     title: Polish `--list`/`--search` output with aligned columns
 
 log:
+  - date: 2026-04-03
+    summary: "mcpipe-6 + mcpipe-7 done: renamed auth_headers → headers throughout McpTransport::Http; replaced _stream_task JoinHandle with AbortHandle (aborted on drop). 28 tests passing."
+    commits: [3ae52cc]
+  - date: 2026-04-03
+    summary: "Sentinel review: 2 blocking issues found (auth_headers field rename, detached JoinHandle). 5 suggestions logged."
   - date: 2026-04-03
     summary: Completed all 5 open items — relative URL fix, --header flag, --fields per-subcommand, integration test gate, --list output polish
     commits: [fb4ff92, aca09b0, 64be13b]

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -140,6 +140,7 @@ items:
   files:
   - src/backend/mcp.rs
   extra: []
+  completed: 2026-04-04
 - id: mcpipe-13
   doob_uuid: c4aa5b7b-9245-4647-84c0-15efaf06d957
   name: maestro-api-openapi-spec

--- a/HANDOFF.mcpipe.workspace.yaml
+++ b/HANDOFF.mcpipe.workspace.yaml
@@ -1,0 +1,80 @@
+project: mcpipe
+id: mcpipe
+updated: 2026-04-03
+branch: main
+state:
+  tests: "28 passing"
+  build: clean
+  notes: HTTP/SSE transport verified against Pieces MCP (~35 tools, execute round-trip confirmed)
+
+items:
+  - id: mcpipe-1
+    name: openapi-relative-server-url
+    priority: P1
+    status: open
+    title: Relative `servers[0].url` in OpenAPI specs breaks HTTP requests
+    description: >
+      Specs like petstore use `/api/v3` as servers[0].url. mcpipe uses it literally,
+      failing the HTTP client. Fix: add `--base-url <URL>` global flag; in
+      OpenApiBackend::execute() prefer user-supplied URL. Also auto-resolve relative
+      server URL against the spec's fetch URL (strip path, append relative URL).
+    files:
+      - src/backend/openapi.rs
+      - src/main.rs
+
+  - id: mcpipe-2
+    name: arbitrary-request-headers
+    priority: P1
+    status: open
+    title: Add `--header KEY:VALUE` flag for arbitrary HTTP headers
+    description: >
+      No way to pass arbitrary headers. GitHub API requires `User-Agent: <app>`.
+      Add repeatable `--header KEY:VALUE` to global parser, thread into OpenApiBackend
+      and GraphQlBackend constructors alongside existing auth headers.
+    files:
+      - src/main.rs
+      - src/backend/openapi.rs
+      - src/backend/graphql.rs
+
+  - id: mcpipe-3
+    name: graphql-fields-override
+    priority: P2
+    status: open
+    title: Wire `--fields` override for GraphQL selection sets
+    description: >
+      GraphQlBackend has with_fields_override() but the CLI doesn't expose it per-subcommand.
+      Add `--fields <FIELDS>` as a per-subcommand arg; in execute() check args for
+      a "__fields" key and use it as the selection set string if present.
+    files:
+      - src/cli.rs
+      - src/backend/graphql.rs
+
+  - id: mcpipe-4
+    name: integration-test-feature-gate
+    priority: P2
+    status: open
+    title: Integration tests behind `--features integration` flag
+    description: >
+      Add [features] integration = [] to Cargo.toml. Gate test files with
+      #![cfg(feature = "integration")]. Write at least one test hitting a real
+      MCP server (echo fixture via stdio, or real HTTP endpoint).
+    files:
+      - Cargo.toml
+      - tests/mcp_adapter.rs
+
+  - id: mcpipe-5
+    name: list-search-output-polish
+    priority: P2
+    status: open
+    title: Polish `--list`/`--search` output with aligned columns
+    description: >
+      Currently prints bare command names one per line. Fix: print `name  —  description`
+      aligned in two columns (max name length for padding). --search already filters
+      by substring — add case-insensitive match. Optional: show param count summary.
+    files:
+      - src/main.rs
+
+log:
+  - date: 2026-04-03
+    summary: Implemented HTTP/SSE transport (HttpSession); verified against Pieces MCP; created HANDOFF.mcpipe.workspace.yaml
+    commits: [d2cebb8, 8ce346c, 996b68a]

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -65,10 +65,44 @@
 
 ---
 
-### 6. `--list`/`--search` output polish
+### ~~6. `--list`/`--search` output polish~~ ✅ DONE (2026-04-03)
 
-**Current:** Prints bare command names one per line.
+Aligned two-column output with description; case-insensitive `--search` working.
 
-**Fix:** Print `name  —  description` aligned in two columns (use `max name length` for padding). `--search PATTERN` already filters by substring — add case-insensitive match. Optional: show param count or required params summary.
+---
 
-**Files:** `src/main.rs` (list/search render block).
+## scan-all Feature — 2026-04-04 ✅ COMPLETE
+
+The `--scan` / scan-all feature is fully implemented and all 35 tests pass.
+
+### What was built
+
+- `DiscoveredSource` domain type and `SourceScanner` port (`src/domain.rs`)
+- `ClaudeConfigScanner` — reads Claude Desktop/Code MCP server config files
+- `WorkspaceScanner` — finds OpenAPI specs (JSON/YAML) in a workspace directory
+- `WellKnownScanner` — probes local HTTP endpoints for live MCP servers (Pieces MCP, etc.)
+- `--scan` flag in `main.rs` wiring all scanners into a unified discovery report
+
+### Known gap — deferred
+
+**GraphQL endpoint heuristics** are not implemented. There is no reliable way to detect a GraphQL
+endpoint without sending a speculative introspection query, which has side effects on some servers.
+Deferred until a safe probe strategy is identified (e.g. OPTIONS + content-type check before
+committing to introspection).
+
+---
+
+## Sentinel Review — 2026-04-03
+
+### Blocking
+
+- [`src/main.rs:60` / `src/backend/mcp.rs:19`] `McpTransport::Http` field named `auth_headers` but receives the merged `all_headers` (auth + user `--header` values). Naming mismatch will cause maintenance bugs — rename field to `headers`.
+- [`src/backend/mcp.rs:138,171`] `_stream_task` `JoinHandle` is never `.await`ed or `.abort()`ed on drop. If the SSE stream task panics, in-flight `oneshot::Sender`s are abandoned and the session is silently dead for its lifetime. Add an abort handle or structured shutdown signal.
+
+### Suggestions
+
+- [`src/main.rs:158–184`] Manual argv stripping for global flags must be kept in sync with `build_global_parser` by hand. A mismatch silently passes unknown flags into the dynamic subcommand parser. Consider deriving the strip list from the parser or adding a round-trip test.
+- [`src/main.rs:77–94`] Relative-URL resolution logic is duplicated between `main.rs` and `mcp.rs`. Extract a `resolve_relative_url(base, path) -> String` utility in `src/lib.rs`.
+- [`src/backend/openapi.rs:180`] `reqwest::Client::new()` on every `execute` call allocates a new connection pool. Build the client once in `from_file`/`from_json` and store it on the struct.
+- [`src/backend/mcp.rs:44`] Child stderr discarded via `Stdio::null()`. Stdio server diagnostics are invisible on crash. Consider forwarding to `eprintln!` via a background reader.
+- [`src/backend/openapi.rs:174`] `ParamLocation::Header` params parsed from spec but never injected into outgoing requests — add a `// TODO` comment so it's not mistaken for intentional behavior.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -12,6 +12,8 @@
 - Secret resolution: `env:VAR`, `file:/path`, literal passthrough
 - Multi-format deserialization (`src/deser.rs`): Content-Type + URL extension hint, fallback chain
 - 28 tests passing; GitHub repo at `https://github.com/89jobrien/mcpipe`
+- `McpBackend`: HTTP/SSE transport (`HttpSession`) — connects to SSE endpoint, waits for `endpoint` event, POSTs JSON-RPC 2.0, routes responses via background stream task + oneshot channels
+- Verified against Pieces MCP (`http://localhost:39300/model_context_protocol/2024-11-05/sse`): ~35 tools discovered, execute round-trip confirmed
 
 ---
 
@@ -27,17 +29,9 @@
 
 ---
 
-### 2. MCP HTTP/SSE transport
+### ~~2. MCP HTTP/SSE transport~~ ✅ DONE (2026-04-03)
 
-**Problem:** `McpBackend::from_http()` returns `Err(BackendError::Transport("MCP HTTP transport not yet implemented"))`.
-
-**Fix:** Implement two sub-modes:
-- **HTTP**: POST JSON-RPC to `{url}/rpc` (or configurable path), use `reqwest`.
-- **SSE**: Connect to `{url}/sse`, parse `eventsource-client` stream for JSON-RPC responses. `eventsource-client` is already in `Cargo.toml`.
-
-MCP HTTP is JSON-RPC 2.0 — same message structure as stdio, different transport layer. `send_request` / `send_notification` / `send_initialize` logic can be shared with stdio.
-
-**Files:** `src/backend/mcp.rs` — add `HttpSession` struct alongside `StdioSession`.
+`HttpSession` implemented in `src/backend/mcp.rs`. Connects to SSE endpoint, waits for `endpoint` event, POSTs JSON-RPC 2.0 via `reqwest`, routes responses from background SSE stream via oneshot channels. Verified against Pieces MCP.
 
 ---
 

--- a/src/backend/cli.rs
+++ b/src/backend/cli.rs
@@ -1,0 +1,194 @@
+use async_trait::async_trait;
+use serde::Deserialize;
+
+use crate::backend::Backend;
+use crate::domain::{ArgMap, BackendError, CommandDef, ParamDef, ParamLocation};
+
+// ── manifest types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct CliManifest {
+    commands: Vec<ManifestCommand>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestCommand {
+    name: String,
+    description: String,
+    params: Vec<ManifestParam>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ManifestParam {
+    name: String,
+    flag: String,
+    required: bool,
+    description: String,
+    #[serde(rename = "type")]
+    ty: String,
+}
+
+// ── CliBackend ────────────────────────────────────────────────────────────────
+
+pub struct CliBackend {
+    command: String,
+}
+
+impl CliBackend {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self { command: command.into() }
+    }
+}
+
+#[async_trait]
+impl Backend for CliBackend {
+    async fn discover(&self) -> Result<Vec<CommandDef>, BackendError> {
+        use tokio::process::Command;
+
+        let output = Command::new(&self.command)
+            .args(["schema", "--json"])
+            .output()
+            .await
+            .map_err(|e| {
+                BackendError::Discovery(format!("failed to run `{}`: {}", self.command, e))
+            })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BackendError::Discovery(format!(
+                "`{} schema` exited non-zero: {}",
+                self.command, stderr
+            )));
+        }
+
+        let manifest: CliManifest = serde_json::from_slice(&output.stdout)
+            .map_err(|e| BackendError::Schema(format!("invalid schema JSON: {e}")))?;
+
+        let cmds = manifest
+            .commands
+            .into_iter()
+            .map(|mc| {
+                let name = mc.name.replace(' ', "-");
+                let params = mc
+                    .params
+                    .into_iter()
+                    .map(|p| ParamDef {
+                        name: p.name.clone(),
+                        original_name: p.flag.trim_start_matches('-').to_string(),
+                        required: p.required,
+                        description: p.description,
+                        location: ParamLocation::ToolInput,
+                        schema: type_str_to_schema(&p.ty),
+                    })
+                    .collect();
+                CommandDef {
+                    name,
+                    description: mc.description,
+                    params,
+                    source_name: self.command.clone(),
+                }
+            })
+            .collect();
+
+        Ok(cmds)
+    }
+
+    async fn execute(&self, cmd: &CommandDef, args: ArgMap) -> Result<serde_json::Value, BackendError> {
+        use tokio::process::Command;
+
+        // "todo-list" -> ["todo", "list"]
+        let parts: Vec<&str> = cmd.name.splitn(2, '-').collect();
+        let mut argv: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
+        argv.push("--json".to_string());
+
+        for param in &cmd.params {
+            let key = &param.name;
+            if let Some(val) = args.get(key) {
+                let flag = format!("--{}", param.original_name.replace('_', "-"));
+                match val {
+                    serde_json::Value::Array(items) => {
+                        for item in items {
+                            let s = match item {
+                                serde_json::Value::String(s) => s.clone(),
+                                other => other.to_string(),
+                            };
+                            argv.push(flag.clone());
+                            argv.push(s);
+                        }
+                    }
+                    serde_json::Value::Null => {}
+                    other => {
+                        argv.push(flag);
+                        argv.push(match other {
+                            serde_json::Value::String(s) => s.clone(),
+                            n => n.to_string(),
+                        });
+                    }
+                }
+            }
+        }
+
+        let output = Command::new(&self.command)
+            .args(&argv)
+            .output()
+            .await
+            .map_err(|e| BackendError::Transport(format!("spawn error: {e}")))?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(BackendError::Execution(format!(
+                "`{} {}` failed: {}",
+                self.command,
+                argv.join(" "),
+                stderr
+            )));
+        }
+
+        let value: serde_json::Value = serde_json::from_slice(&output.stdout)
+            .map_err(|e| BackendError::Execution(format!("JSON parse error: {e}")))?;
+
+        Ok(value)
+    }
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+fn type_str_to_schema(ty: &str) -> serde_json::Value {
+    match ty {
+        "integer" => serde_json::json!({"type": "integer"}),
+        "boolean" => serde_json::json!({"type": "boolean"}),
+        "array" => serde_json::json!({"type": "array", "items": {"type": "string"}}),
+        _ => serde_json::json!({"type": "string"}),
+    }
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn discover_doob_commands() {
+        let backend = CliBackend::new("doob");
+        let cmds = backend.discover().await.unwrap();
+        assert!(cmds.len() > 5);
+        assert!(cmds.iter().any(|c| c.name == "todo-list"));
+        assert!(cmds.iter().any(|c| c.name == "todo-add"));
+        assert!(cmds.iter().any(|c| c.name == "search"));
+    }
+
+    #[cfg(feature = "integration")]
+    #[tokio::test]
+    async fn execute_doob_todo_list() {
+        let backend = CliBackend::new("doob");
+        let cmds = backend.discover().await.unwrap();
+        let list_cmd = cmds.iter().find(|c| c.name == "todo-list").unwrap().clone();
+        let result = backend
+            .execute(&list_cmd, std::collections::HashMap::new())
+            .await
+            .unwrap();
+        assert!(result.get("todos").is_some() || result.get("count").is_some());
+    }
+}

--- a/src/backend/cli.rs
+++ b/src/backend/cli.rs
@@ -96,7 +96,9 @@ impl Backend for CliBackend {
     async fn execute(&self, cmd: &CommandDef, args: ArgMap) -> Result<serde_json::Value, BackendError> {
         use tokio::process::Command;
 
-        // "todo-list" -> ["todo", "list"]
+        // "todo-list" -> ["todo", "list"]; single-word "search" -> ["search"].
+        // Constraint: command names with >1 hyphen (e.g. "todo-add-tag") are not supported —
+        // the manifest must use at most one level of nesting.
         let parts: Vec<&str> = cmd.name.splitn(2, '-').collect();
         let mut argv: Vec<String> = parts.iter().map(|s| s.to_string()).collect();
         argv.push("--json".to_string());

--- a/src/backend/graphql.rs
+++ b/src/backend/graphql.rs
@@ -117,7 +117,11 @@ impl Backend for GraphQlBackend {
     }
 
     async fn execute(&self, cmd: &CommandDef, args: ArgMap) -> Result<serde_json::Value, BackendError> {
+        // Extract per-subcommand fields override (not a real GraphQL arg)
+        let per_call_fields = args.get("__fields").and_then(|v| v.as_str()).map(|s| s.to_string());
+
         let arg_str: String = args.iter()
+            .filter(|(k, _)| k.as_str() != "__fields")
             .map(|(k, v)| format!("{}: {}", k, v))
             .collect::<Vec<_>>()
             .join(", ");
@@ -128,7 +132,9 @@ impl Backend for GraphQlBackend {
             format!("{}({})", cmd.source_name, arg_str)
         };
 
-        let fields = self.fields_override.clone().unwrap_or_else(|| "id".to_string());
+        let fields = per_call_fields
+            .or_else(|| self.fields_override.clone())
+            .unwrap_or_else(|| "id".to_string());
         let query = format!("{{ {} {{ {} }} }}", call, fields);
 
         let client = reqwest::Client::new();

--- a/src/backend/mcp.rs
+++ b/src/backend/mcp.rs
@@ -1,7 +1,9 @@
 use async_trait::async_trait;
+use eventsource_client::{Client as SseClient, ClientBuilder as SseClientBuilder, SSE};
+use futures::StreamExt;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::process::Command;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 
 use crate::domain::{ArgMap, BackendError, CommandDef, ParamDef, ParamLocation};
 use crate::backend::openapi::to_kebab;
@@ -54,6 +56,52 @@ impl McpBackend {
         let result = f(session).await;
         let _ = child.kill().await;
         result
+    }
+
+    async fn run_http_session<F, Fut>(&self, url: &str, auth_headers: &[(String, String)], f: F) -> Result<serde_json::Value, BackendError>
+    where
+        F: FnOnce(HttpSession) -> Fut,
+        Fut: std::future::Future<Output = Result<serde_json::Value, BackendError>>,
+    {
+        // Parse base URL to reconstruct absolute POST URL from the relative endpoint path
+        let base_url = {
+            let parsed = url::Url::parse(url)
+                .map_err(|e| BackendError::Transport(format!("invalid URL: {e}")))?;
+            format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or("localhost"))
+                + &parsed.port().map(|p| format!(":{p}")).unwrap_or_default()
+        };
+
+        // Build SSE client
+        let mut builder = SseClientBuilder::for_url(url)
+            .map_err(|e| BackendError::Transport(format!("SSE client build: {e}")))?;
+        for (name, value) in auth_headers {
+            builder = builder.header(name, value)
+                .map_err(|e| BackendError::Transport(format!("SSE header: {e}")))?;
+        }
+        let sse_client = builder.build();
+        let mut stream = Box::pin(sse_client.stream());
+
+        // Wait for the endpoint event
+        let post_path = loop {
+            match stream.next().await {
+                Some(Ok(SSE::Event(evt))) if evt.event_type == "endpoint" => {
+                    break evt.data;
+                }
+                Some(Ok(_)) => continue,
+                Some(Err(e)) => return Err(BackendError::Transport(format!("SSE error waiting for endpoint: {e}"))),
+                None => return Err(BackendError::Transport("SSE stream closed before endpoint event".to_string())),
+            }
+        };
+
+        let post_url = if post_path.starts_with("http://") || post_path.starts_with("https://") {
+            post_path
+        } else {
+            format!("{base_url}{post_path}")
+        };
+
+        let session = HttpSession::new(post_url, auth_headers.to_vec(), stream);
+        session.send_initialize().await?;
+        f(session).await
     }
 }
 
@@ -138,6 +186,126 @@ impl StdioSession {
     }
 }
 
+/// SSE stream type alias
+type SseStream = std::pin::Pin<Box<dyn futures::Stream<Item = Result<SSE, eventsource_client::Error>> + Send + Sync>>;
+
+struct HttpSession {
+    post_url: String,
+    auth_headers: Vec<(String, String)>,
+    http_client: reqwest::Client,
+    /// Pending response channels keyed by request id
+    pending: std::sync::Arc<Mutex<std::collections::HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
+    next_id: Mutex<u64>,
+    /// SSE stream (driven by a background task)
+    _stream_task: tokio::task::JoinHandle<()>,
+}
+
+impl HttpSession {
+    fn new(post_url: String, auth_headers: Vec<(String, String)>, stream: SseStream) -> Self {
+        let pending: std::sync::Arc<Mutex<std::collections::HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
+            std::sync::Arc::new(Mutex::new(std::collections::HashMap::new()));
+        let pending_clone = pending.clone();
+
+        // Drive the SSE stream in background, routing responses to waiting senders
+        let stream_task = tokio::spawn(async move {
+            let mut stream = stream;
+            while let Some(item) = stream.next().await {
+                match item {
+                    Ok(SSE::Event(evt)) if evt.event_type == "message" => {
+                        if let Ok(val) = serde_json::from_str::<serde_json::Value>(&evt.data) {
+                            let Some(id) = val.get("id").and_then(|v| v.as_u64()) else { continue };
+                            if let Some(tx) = pending_clone.lock().await.remove(&id) {
+                                let _ = tx.send(val);
+                            }
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(_) => break,
+                }
+            }
+        });
+
+        Self {
+            post_url,
+            auth_headers,
+            http_client: reqwest::Client::new(),
+            pending,
+            next_id: Mutex::new(1),
+            _stream_task: stream_task,
+        }
+    }
+
+    async fn next_id(&self) -> u64 {
+        let mut id = self.next_id.lock().await;
+        let cur = *id;
+        *id += 1;
+        cur
+    }
+
+    async fn send_request(&self, method: &str, params: serde_json::Value) -> Result<serde_json::Value, BackendError> {
+        let id = self.next_id().await;
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params,
+        });
+
+        let (tx, rx) = oneshot::channel();
+        self.pending.lock().await.insert(id, tx);
+
+        let mut req = self.http_client.post(&self.post_url)
+            .header("Content-Type", "application/json")
+            .json(&msg);
+        for (name, value) in &self.auth_headers {
+            req = req.header(name.as_str(), value.as_str());
+        }
+
+        req.send().await
+            .map_err(|e| BackendError::Transport(format!("POST {}: {e}", self.post_url)))?;
+
+        // Wait for the SSE stream to deliver the response
+        let response = tokio::time::timeout(
+            std::time::Duration::from_secs(30),
+            rx,
+        ).await
+            .map_err(|_| BackendError::Transport("timeout waiting for MCP response".to_string()))?
+            .map_err(|_| BackendError::Transport("response channel dropped".to_string()))?;
+
+        if let Some(err) = response.get("error") {
+            return Err(BackendError::Execution(err.to_string()));
+        }
+        Ok(response.get("result").cloned().unwrap_or(serde_json::Value::Null))
+    }
+
+    async fn send_notification(&self, method: &str, params: serde_json::Value) -> Result<(), BackendError> {
+        let msg = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": method,
+            "params": params,
+        });
+        let mut req = self.http_client.post(&self.post_url)
+            .header("Content-Type", "application/json")
+            .json(&msg);
+        for (name, value) in &self.auth_headers {
+            req = req.header(name.as_str(), value.as_str());
+        }
+        req.send().await
+            .map_err(|e| BackendError::Transport(format!("POST notification: {e}")))?;
+        Ok(())
+    }
+
+    async fn send_initialize(&self) -> Result<(), BackendError> {
+        self.send_request("initialize", serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": { "name": "mcpipe", "version": "0.1.0" }
+        })).await?;
+        self.send_notification("notifications/initialized", serde_json::json!({})).await?;
+        Ok(())
+    }
+}
+
 fn tools_to_commands(tools: &[serde_json::Value]) -> Vec<CommandDef> {
     tools.iter().map(|tool| {
         let name = tool.get("name").and_then(|v| v.as_str()).unwrap_or("tool");
@@ -192,8 +360,20 @@ impl Backend for McpBackend {
                 }).await
                 .and_then(|v| serde_json::from_value(v).map_err(|e| BackendError::Schema(e.to_string())))
             }
-            McpTransport::Http { .. } => {
-                Err(BackendError::Transport("MCP HTTP transport not yet implemented".to_string()))
+            McpTransport::Http { url, auth_headers } => {
+                let url = url.clone();
+                let auth_headers = auth_headers.clone();
+                self.run_http_session(&url, &auth_headers, |session| async move {
+                    let result = session.send_request("tools/list", serde_json::json!({})).await?;
+                    let tools = result.get("tools")
+                        .and_then(|v| v.as_array())
+                        .cloned()
+                        .unwrap_or_default();
+                    let cmds = tools_to_commands(&tools);
+                    serde_json::to_value(cmds)
+                        .map_err(|e| BackendError::Schema(e.to_string()))
+                }).await
+                .and_then(|v| serde_json::from_value(v).map_err(|e| BackendError::Schema(e.to_string())))
             }
         }
     }
@@ -211,8 +391,17 @@ impl Backend for McpBackend {
                     Ok(result.get("content").cloned().unwrap_or(result))
                 }).await
             }
-            McpTransport::Http { .. } => {
-                Err(BackendError::Transport("MCP HTTP transport not yet implemented".to_string()))
+            McpTransport::Http { url, auth_headers } => {
+                let url = url.clone();
+                let auth_headers = auth_headers.clone();
+                let tool_name = cmd.source_name.clone();
+                self.run_http_session(&url, &auth_headers, |session| async move {
+                    let result = session.send_request("tools/call", serde_json::json!({
+                        "name": tool_name,
+                        "arguments": args,
+                    })).await?;
+                    Ok(result.get("content").cloned().unwrap_or(result))
+                }).await
             }
         }
     }

--- a/src/backend/mcp.rs
+++ b/src/backend/mcp.rs
@@ -16,7 +16,7 @@ pub struct McpBackend {
 #[allow(dead_code)]
 enum McpTransport {
     Stdio { command: String },
-    Http  { url: String, auth_headers: Vec<(String, String)> },
+    Http  { url: String, headers: Vec<(String, String)> },
 }
 
 impl McpBackend {
@@ -24,8 +24,8 @@ impl McpBackend {
         Self { inner: McpTransport::Stdio { command } }
     }
 
-    pub fn from_http(url: String, auth_headers: Vec<(String, String)>) -> Self {
-        Self { inner: McpTransport::Http { url, auth_headers } }
+    pub fn from_http(url: String, headers: Vec<(String, String)>) -> Self {
+        Self { inner: McpTransport::Http { url, headers } }
     }
 
     async fn run_stdio_session<F, Fut>(&self, command: &str, f: F) -> Result<serde_json::Value, BackendError>
@@ -58,7 +58,7 @@ impl McpBackend {
         result
     }
 
-    async fn run_http_session<F, Fut>(&self, url: &str, auth_headers: &[(String, String)], f: F) -> Result<serde_json::Value, BackendError>
+    async fn run_http_session<F, Fut>(&self, url: &str, headers: &[(String, String)], f: F) -> Result<serde_json::Value, BackendError>
     where
         F: FnOnce(HttpSession) -> Fut,
         Fut: std::future::Future<Output = Result<serde_json::Value, BackendError>>,
@@ -74,7 +74,7 @@ impl McpBackend {
         // Build SSE client
         let mut builder = SseClientBuilder::for_url(url)
             .map_err(|e| BackendError::Transport(format!("SSE client build: {e}")))?;
-        for (name, value) in auth_headers {
+        for (name, value) in headers {
             builder = builder.header(name, value)
                 .map_err(|e| BackendError::Transport(format!("SSE header: {e}")))?;
         }
@@ -99,7 +99,7 @@ impl McpBackend {
             format!("{base_url}{post_path}")
         };
 
-        let session = HttpSession::new(post_url, auth_headers.to_vec(), stream);
+        let session = HttpSession::new(post_url, headers.to_vec(), stream);
         session.send_initialize().await?;
         f(session).await
     }
@@ -191,22 +191,24 @@ type SseStream = std::pin::Pin<Box<dyn futures::Stream<Item = Result<SSE, events
 
 struct HttpSession {
     post_url: String,
-    auth_headers: Vec<(String, String)>,
+    headers: Vec<(String, String)>,
     http_client: reqwest::Client,
     /// Pending response channels keyed by request id
     pending: std::sync::Arc<Mutex<std::collections::HashMap<u64, oneshot::Sender<serde_json::Value>>>>,
     next_id: Mutex<u64>,
-    /// SSE stream (driven by a background task)
-    _stream_task: tokio::task::JoinHandle<()>,
+    /// Abort handle for the background SSE stream task; aborted on drop.
+    _stream_abort: tokio::task::AbortHandle,
 }
 
 impl HttpSession {
-    fn new(post_url: String, auth_headers: Vec<(String, String)>, stream: SseStream) -> Self {
+    fn new(post_url: String, headers: Vec<(String, String)>, stream: SseStream) -> Self {
         let pending: std::sync::Arc<Mutex<std::collections::HashMap<u64, oneshot::Sender<serde_json::Value>>>> =
             std::sync::Arc::new(Mutex::new(std::collections::HashMap::new()));
         let pending_clone = pending.clone();
 
-        // Drive the SSE stream in background, routing responses to waiting senders
+        // Drive the SSE stream in background, routing responses to waiting senders.
+        // The AbortHandle is stored on HttpSession and aborted on drop; we drop the
+        // JoinHandle here so the task runs detached (abort_handle remains valid).
         let stream_task = tokio::spawn(async move {
             let mut stream = stream;
             while let Some(item) = stream.next().await {
@@ -227,11 +229,11 @@ impl HttpSession {
 
         Self {
             post_url,
-            auth_headers,
+            headers,
             http_client: reqwest::Client::new(),
             pending,
             next_id: Mutex::new(1),
-            _stream_task: stream_task,
+            _stream_abort: stream_task.abort_handle(),
         }
     }
 
@@ -257,7 +259,7 @@ impl HttpSession {
         let mut req = self.http_client.post(&self.post_url)
             .header("Content-Type", "application/json")
             .json(&msg);
-        for (name, value) in &self.auth_headers {
+        for (name, value) in &self.headers {
             req = req.header(name.as_str(), value.as_str());
         }
 
@@ -287,7 +289,7 @@ impl HttpSession {
         let mut req = self.http_client.post(&self.post_url)
             .header("Content-Type", "application/json")
             .json(&msg);
-        for (name, value) in &self.auth_headers {
+        for (name, value) in &self.headers {
             req = req.header(name.as_str(), value.as_str());
         }
         req.send().await
@@ -360,10 +362,10 @@ impl Backend for McpBackend {
                 }).await
                 .and_then(|v| serde_json::from_value(v).map_err(|e| BackendError::Schema(e.to_string())))
             }
-            McpTransport::Http { url, auth_headers } => {
+            McpTransport::Http { url, headers } => {
                 let url = url.clone();
-                let auth_headers = auth_headers.clone();
-                self.run_http_session(&url, &auth_headers, |session| async move {
+                let headers = headers.clone();
+                self.run_http_session(&url, &headers, |session| async move {
                     let result = session.send_request("tools/list", serde_json::json!({})).await?;
                     let tools = result.get("tools")
                         .and_then(|v| v.as_array())
@@ -391,11 +393,11 @@ impl Backend for McpBackend {
                     Ok(result.get("content").cloned().unwrap_or(result))
                 }).await
             }
-            McpTransport::Http { url, auth_headers } => {
+            McpTransport::Http { url, headers } => {
                 let url = url.clone();
-                let auth_headers = auth_headers.clone();
+                let headers = headers.clone();
                 let tool_name = cmd.source_name.clone();
-                self.run_http_session(&url, &auth_headers, |session| async move {
+                self.run_http_session(&url, &headers, |session| async move {
                     let result = session.send_request("tools/call", serde_json::json!({
                         "name": tool_name,
                         "arguments": args,

--- a/src/backend/mcp.rs
+++ b/src/backend/mcp.rs
@@ -308,6 +308,12 @@ impl HttpSession {
     }
 }
 
+impl Drop for HttpSession {
+    fn drop(&mut self) {
+        self._stream_abort.abort();
+    }
+}
+
 fn tools_to_commands(tools: &[serde_json::Value]) -> Vec<CommandDef> {
     tools.iter().map(|tool| {
         let name = tool.get("name").and_then(|v| v.as_str()).unwrap_or("tool");

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,6 +1,7 @@
+pub mod cli;
+pub mod graphql;
 pub mod mcp;
 pub mod openapi;
-pub mod graphql;
 
 use async_trait::async_trait;
 use crate::domain::{ArgMap, BackendError, CommandDef};

--- a/src/backend/openapi.rs
+++ b/src/backend/openapi.rs
@@ -30,6 +30,16 @@ impl OpenApiBackend {
         Self { spec, base_url, auth_headers }
     }
 
+    pub fn with_base_url(mut self, base_url: String) -> Self {
+        self.base_url = base_url;
+        self
+    }
+
+    pub fn with_auth_headers(mut self, headers: Vec<(String, String)>) -> Self {
+        self.auth_headers = headers;
+        self
+    }
+
     fn build_commands(&self) -> Result<Vec<CommandDef>, BackendError> {
         let spec = resolve_refs(&self.spec);
         let paths = spec.get("paths")

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -20,6 +20,15 @@ pub fn build_command(app_name: &str, cmds: &[CommandDef]) -> Command {
             sub = sub.arg(arg);
         }
 
+        // Per-subcommand --fields override for GraphQL selection sets
+        sub = sub.arg(
+            Arg::new("__fields")
+                .long("fields")
+                .value_name("FIELDS")
+                .required(false)
+                .help("GraphQL selection set fields (e.g. 'id name createdAt')"),
+        );
+
         app = app.subcommand(sub);
     }
 
@@ -67,6 +76,11 @@ pub fn extract_args(matches: &ArgMatches, cmd: &CommandDef) -> ArgMap {
             let coerced = coerce(raw, &param.schema);
             map.insert(param.original_name.clone(), coerced);
         }
+    }
+
+    // Capture per-subcommand --fields override as a special key
+    if let Some(fields) = matches.get_one::<String>("__fields") {
+        map.insert("__fields".to_string(), serde_json::Value::String(fields.clone()));
     }
 
     map

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -1,0 +1,30 @@
+use async_trait::async_trait;
+
+/// One discovered API source — enough to construct a Backend and run discover().
+#[derive(Debug, Clone)]
+pub struct DiscoveredSource {
+    /// Human-readable name (from config key or derived from URL/command).
+    pub name: String,
+    /// How to connect.
+    pub kind: BackendKind,
+    /// Where this source was found (config file path, workspace path, etc.).
+    pub origin: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum BackendKind {
+    /// MCP over stdio — spawn a process.
+    McpStdio { command: String },
+    /// MCP over HTTP/SSE.
+    McpHttp { url: String },
+    /// OpenAPI spec at a file path.
+    OpenApiFile { path: String },
+    /// GraphQL endpoint URL.
+    GraphQL { url: String },
+}
+
+/// Port: anything that can produce a list of DiscoveredSources.
+#[async_trait]
+pub trait SourceScanner: Send + Sync {
+    async fn scan(&self) -> Vec<DiscoveredSource>;
+}

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -23,6 +23,24 @@ pub enum BackendKind {
     GraphQL { url: String },
 }
 
+impl DiscoveredSource {
+    pub fn into_backend(self) -> Box<dyn crate::backend::Backend> {
+        use crate::backend::mcp::McpBackend;
+        match self.kind {
+            BackendKind::McpStdio { command } => Box::new(McpBackend::from_stdio(command)),
+            BackendKind::McpHttp { url } => Box::new(McpBackend::from_http(url, vec![])),
+            BackendKind::OpenApiFile { path } => {
+                use crate::backend::openapi::OpenApiBackend;
+                Box::new(OpenApiBackend::from_file(&path).expect("openapi load"))
+            }
+            BackendKind::GraphQL { url } => {
+                use crate::backend::graphql::GraphQlBackend;
+                Box::new(GraphQlBackend::new(url, vec![]))
+            }
+        }
+    }
+}
+
 /// Port: anything that can produce a list of DiscoveredSources.
 #[async_trait]
 pub trait SourceScanner: Send + Sync {

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -21,6 +21,8 @@ pub enum BackendKind {
     OpenApiFile { path: String },
     /// GraphQL endpoint URL.
     GraphQL { url: String },
+    /// CLI tool exposing a `schema` subcommand.
+    Cli { command: String },
 }
 
 impl DiscoveredSource {
@@ -37,7 +39,26 @@ impl DiscoveredSource {
                 use crate::backend::graphql::GraphQlBackend;
                 Box::new(GraphQlBackend::new(url, vec![]))
             }
+            BackendKind::Cli { command } => {
+                use crate::backend::cli::CliBackend;
+                Box::new(CliBackend::new(command))
+            }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cli_backend_kind_into_backend() {
+        let source = DiscoveredSource {
+            name: "doob".to_string(),
+            kind: BackendKind::Cli { command: "doob".to_string() },
+            origin: "manual".to_string(),
+        };
+        let _backend = source.into_backend();
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod scanner;
 pub mod deser;
 pub mod discovery;
 pub mod domain;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod deser;
+pub mod discovery;
 pub mod domain;
 pub mod backend;
 pub mod secret;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,4 @@ pub mod secret;
 pub mod format;
 pub mod cache;
 pub mod cli;
+pub mod openapi_gen;

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ async fn run() -> Result<()> {
     let jq = matches.get_one::<String>("jq").cloned();
     let head = matches.get_one::<usize>("head").copied();
     let list_only = matches.get_flag("list");
+    let scan_mode = matches.get_flag("scan");
     let search = matches.get_one::<String>("search").cloned();
     let refresh = matches.get_flag("refresh");
     let cache_ttl = *matches.get_one::<u64>("cache-ttl").unwrap_or(&3600);
@@ -58,6 +59,10 @@ async fn run() -> Result<()> {
 
     // Merge auth + extra headers
     let all_headers: Vec<(String, String)> = auth_headers.iter().cloned().chain(extra_headers).collect();
+
+    if scan_mode {
+        return run_scan().await;
+    }
 
     // Build backend
     let backend: Box<dyn Backend> = if let Some(cmd) = matches.get_one::<String>("mcp-stdio") {
@@ -160,7 +165,7 @@ async fn run() -> Result<()> {
         "--mcp-stdio", "--mcp", "--spec", "--graphql",
         "--auth-header", "--header", "--base-url", "--cache-ttl", "--jq", "--head", "--search", "--fields",
     ];
-    let global_bool_flags = ["--pretty", "--raw", "--refresh", "--list"];
+    let global_bool_flags = ["--pretty", "--raw", "--refresh", "--list", "--scan"];
 
     let mut tool_args = vec!["mcpipe".to_string()];
     let mut skip_next = false;
@@ -216,12 +221,81 @@ fn build_global_parser() -> Command {
         .arg(Arg::new("raw").long("raw").action(ArgAction::SetTrue).help("Print raw string values"))
         .arg(Arg::new("refresh").long("refresh").action(ArgAction::SetTrue).help("Bypass cache, re-fetch"))
         .arg(Arg::new("list").long("list").action(ArgAction::SetTrue).help("List available subcommands"))
+        .arg(Arg::new("scan").long("scan").action(ArgAction::SetTrue)
+            .help("Auto-discover all API surfaces and print a unified catalog"))
         .arg(Arg::new("search").long("search").value_name("PATTERN").help("Search commands by name/description"))
         .arg(Arg::new("cache-ttl").long("cache-ttl").value_name("SECS").value_parser(clap::value_parser!(u64)).help("Cache TTL in seconds (default: 3600)"))
         .arg(Arg::new("jq").long("jq").value_name("EXPR").help("Filter output through jq"))
         .arg(Arg::new("head").long("head").value_name("N").value_parser(clap::value_parser!(usize)).help("Limit output to first N array elements"))
         .arg(Arg::new("fields").long("fields").value_name("FIELDS").help("Override GraphQL selection set fields"))
         .allow_external_subcommands(true)
+}
+
+async fn run_scan() -> anyhow::Result<()> {
+    use mcpipe::scanner::claude_config::ClaudeConfigScanner;
+    use mcpipe::scanner::workspace::WorkspaceScanner;
+    use mcpipe::scanner::well_known::WellKnownScanner;
+    use mcpipe::discovery::SourceScanner;
+
+    eprintln!("Scanning for API surfaces...");
+
+    let scanners: Vec<Box<dyn SourceScanner>> = vec![
+        Box::new(ClaudeConfigScanner::default_env()),
+        Box::new(WorkspaceScanner::default_env()),
+        Box::new(WellKnownScanner::new()),
+    ];
+
+    let scan_futures: Vec<_> = scanners.iter().map(|s| s.scan()).collect();
+    let all_results = futures::future::join_all(scan_futures).await;
+
+    let mut all_sources: Vec<_> = all_results.into_iter().flatten().collect();
+    all_sources.sort_by(|a, b| a.name.cmp(&b.name));
+
+    if all_sources.is_empty() {
+        println!("No API surfaces found.");
+        return Ok(());
+    }
+
+    eprintln!("Found {} source(s). Discovering tools...\n", all_sources.len());
+
+    let discover_futures: Vec<_> = all_sources.iter().map(|src| {
+        let backend = src.clone().into_backend();
+        let name = src.name.clone();
+        let origin = src.origin.clone();
+        async move {
+            let result = tokio::time::timeout(
+                std::time::Duration::from_secs(10),
+                backend.discover(),
+            ).await;
+            (name, origin, result)
+        }
+    }).collect();
+
+    let results = futures::future::join_all(discover_futures).await;
+
+    let mut total = 0usize;
+    for (name, origin, result) in &results {
+        match result {
+            Ok(Ok(cmds)) => {
+                println!("## {} ({})", name, origin);
+                let max_w = cmds.iter().map(|c| c.name.len()).max().unwrap_or(10).max(10);
+                for cmd in cmds {
+                    println!("  {:<width$}  {}", cmd.name, cmd.description, width = max_w);
+                }
+                println!("  ({} tools)\n", cmds.len());
+                total += cmds.len();
+            }
+            Ok(Err(e)) => {
+                println!("## {} — ERROR: {}\n", name, e);
+            }
+            Err(_) => {
+                println!("## {} — TIMEOUT (>10s)\n", name);
+            }
+        }
+    }
+
+    println!("Total: {} tools across {} sources.", total, results.len());
+    Ok(())
 }
 
 async fn fetch_spec(url: &str, auth_headers: &[(String, String)]) -> Result<serde_json::Value> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -106,9 +106,34 @@ async fn run() -> Result<()> {
             b = b.with_auth_headers(all_headers.clone());
             Box::new(b)
         }
+    } else if let Some(cli_cmd) = matches.get_one::<String>("cli") {
+        use mcpipe::backend::cli::CliBackend;
+        Box::new(CliBackend::new(cli_cmd.clone()))
     } else {
-        bail!("specify one of --mcp-stdio, --mcp, --spec, or --graphql");
+        bail!("specify one of --mcp-stdio, --mcp, --spec, --graphql, or --cli");
     };
+
+    let gen_openapi = matches.get_flag("gen-openapi");
+    let openapi_output = matches.get_one::<String>("openapi-output").cloned();
+
+    if gen_openapi {
+        let commands = backend.discover().await
+            .context("discovering commands for OpenAPI generation")?;
+        let tool_name = matches.get_one::<String>("cli")
+            .map(|s| s.as_str())
+            .unwrap_or("api");
+        let doc = mcpipe::openapi_gen::generate(tool_name, "0.1.0", &commands);
+        let yaml = mcpipe::openapi_gen::to_yaml(&doc)
+            .context("serializing OpenAPI spec to YAML")?;
+        if let Some(path) = openapi_output {
+            std::fs::write(&path, &yaml)
+                .with_context(|| format!("writing OpenAPI spec to {path}"))?;
+            eprintln!("Wrote OpenAPI spec to {path}");
+        } else {
+            print!("{yaml}");
+        }
+        return Ok(());
+    }
 
     // Cache source key (only for non-stdio backends)
     let cache_source = matches.get_one::<String>("mcp")
@@ -164,8 +189,9 @@ async fn run() -> Result<()> {
     let global_value_flags = [
         "--mcp-stdio", "--mcp", "--spec", "--graphql",
         "--auth-header", "--header", "--base-url", "--cache-ttl", "--jq", "--head", "--search", "--fields",
+        "--cli", "--openapi-output",
     ];
-    let global_bool_flags = ["--pretty", "--raw", "--refresh", "--list", "--scan"];
+    let global_bool_flags = ["--pretty", "--raw", "--refresh", "--list", "--scan", "--gen-openapi"];
 
     let mut tool_args = vec!["mcpipe".to_string()];
     let mut skip_next = false;
@@ -228,6 +254,26 @@ fn build_global_parser() -> Command {
         .arg(Arg::new("jq").long("jq").value_name("EXPR").help("Filter output through jq"))
         .arg(Arg::new("head").long("head").value_name("N").value_parser(clap::value_parser!(usize)).help("Limit output to first N array elements"))
         .arg(Arg::new("fields").long("fields").value_name("FIELDS").help("Override GraphQL selection set fields"))
+        .arg(
+            Arg::new("cli")
+                .long("cli")
+                .value_name("COMMAND")
+                .help("CLI tool exposing a `schema` subcommand (e.g. doob)")
+                .num_args(1),
+        )
+        .arg(
+            Arg::new("gen-openapi")
+                .long("gen-openapi")
+                .action(ArgAction::SetTrue)
+                .help("Generate OpenAPI 3.1 spec from discovered commands and print to stdout"),
+        )
+        .arg(
+            Arg::new("openapi-output")
+                .long("openapi-output")
+                .value_name("FILE")
+                .help("Write generated OpenAPI spec to FILE instead of stdout")
+                .num_args(1),
+        )
         .allow_external_subcommands(true)
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,10 @@ async fn run() -> Result<()> {
     let gen_openapi = matches.get_flag("gen-openapi");
     let openapi_output = matches.get_one::<String>("openapi-output").cloned();
 
+    if gen_openapi && matches.get_one::<String>("cli").is_none() {
+        bail!("--gen-openapi requires --cli <COMMAND>");
+    }
+
     if gen_openapi {
         let commands = backend.discover().await
             .context("discovering commands for OpenAPI generation")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,27 +47,59 @@ async fn run() -> Result<()> {
         })
         .collect();
 
+    let extra_headers: Vec<(String, String)> = matches
+        .get_many::<String>("header")
+        .unwrap_or_default()
+        .filter_map(|h| {
+            let (k, v) = h.split_once(':')?;
+            Some((k.trim().to_string(), v.trim().to_string()))
+        })
+        .collect();
+
+    // Merge auth + extra headers
+    let all_headers: Vec<(String, String)> = auth_headers.iter().cloned().chain(extra_headers).collect();
+
     // Build backend
     let backend: Box<dyn Backend> = if let Some(cmd) = matches.get_one::<String>("mcp-stdio") {
         Box::new(McpBackend::from_stdio(cmd.clone()))
     } else if let Some(url) = matches.get_one::<String>("mcp") {
-        Box::new(McpBackend::from_http(url.clone(), auth_headers.clone()))
+        Box::new(McpBackend::from_http(url.clone(), all_headers.clone()))
     } else if let Some(url) = matches.get_one::<String>("graphql") {
-        let mut b = GraphQlBackend::new(url.clone(), auth_headers.clone());
+        let mut b = GraphQlBackend::new(url.clone(), all_headers.clone());
         if let Some(fields) = matches.get_one::<String>("fields") {
             b = b.with_fields_override(fields.clone());
         }
         Box::new(b)
     } else if let Some(spec) = matches.get_one::<String>("spec") {
+        let user_base_url = matches.get_one::<String>("base-url").cloned();
         if spec.starts_with("http://") || spec.starts_with("https://") {
-            let spec_json = fetch_spec(spec, &auth_headers).await?;
-            let base_url = spec_json.pointer("/servers/0/url")
-                .and_then(|v| v.as_str())
-                .unwrap_or("http://localhost")
-                .to_string();
-            Box::new(OpenApiBackend::from_json(spec_json, base_url, auth_headers.clone()))
+            let spec_json = fetch_spec(spec, &all_headers).await?;
+            let base_url = user_base_url.unwrap_or_else(|| {
+                let raw = spec_json.pointer("/servers/0/url")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("http://localhost");
+                // Auto-resolve relative URLs against the spec's fetch URL
+                if raw.starts_with("http://") || raw.starts_with("https://") {
+                    raw.to_string()
+                } else {
+                    // Strip path from spec URL and append relative server URL
+                    if let Ok(parsed) = url::Url::parse(spec) {
+                        let origin = format!("{}://{}", parsed.scheme(), parsed.host_str().unwrap_or("localhost"));
+                        let port_str = parsed.port().map(|p| format!(":{p}")).unwrap_or_default();
+                        format!("{}{}{}", origin, port_str, raw)
+                    } else {
+                        raw.to_string()
+                    }
+                }
+            });
+            Box::new(OpenApiBackend::from_json(spec_json, base_url, all_headers.clone()))
         } else {
-            Box::new(OpenApiBackend::from_file(spec).context("loading OpenAPI spec")?)
+            let mut b = OpenApiBackend::from_file(spec).context("loading OpenAPI spec")?;
+            if let Some(bu) = user_base_url {
+                b = b.with_base_url(bu);
+            }
+            b = b.with_auth_headers(all_headers.clone());
+            Box::new(b)
         }
     } else {
         bail!("specify one of --mcp-stdio, --mcp, --spec, or --graphql");
@@ -103,13 +135,18 @@ async fn run() -> Result<()> {
     // --list / --search
     if list_only || search.is_some() {
         let pattern = search.as_deref().unwrap_or("").to_lowercase();
-        for cmd in &cmds {
-            if pattern.is_empty()
-                || cmd.name.contains(&pattern)
+        let filtered: Vec<_> = cmds.iter().filter(|cmd| {
+            pattern.is_empty()
+                || cmd.name.to_lowercase().contains(&pattern)
                 || cmd.description.to_lowercase().contains(&pattern)
-            {
-                println!("{:30}  {}", cmd.name, cmd.description);
-            }
+        }).collect();
+
+        let max_name = filtered.iter().map(|c| c.name.len()).max().unwrap_or(20);
+        let width = max_name.max(10);
+        for cmd in &filtered {
+            let param_count = cmd.params.len();
+            let suffix = if param_count > 0 { format!(" ({param_count} params)") } else { String::new() };
+            println!("{:<width$}  {}{}",  cmd.name, cmd.description, suffix);
         }
         return Ok(());
     }
@@ -121,7 +158,7 @@ async fn run() -> Result<()> {
     let raw_args: Vec<String> = std::env::args().skip(1).collect();
     let global_value_flags = [
         "--mcp-stdio", "--mcp", "--spec", "--graphql",
-        "--auth-header", "--cache-ttl", "--jq", "--head", "--search", "--fields",
+        "--auth-header", "--header", "--base-url", "--cache-ttl", "--jq", "--head", "--search", "--fields",
     ];
     let global_bool_flags = ["--pretty", "--raw", "--refresh", "--list"];
 
@@ -172,7 +209,9 @@ fn build_global_parser() -> Command {
         .arg(Arg::new("mcp").long("mcp").value_name("URL").help("MCP server URL (HTTP/SSE)"))
         .arg(Arg::new("spec").long("spec").value_name("URL_OR_FILE").help("OpenAPI spec URL or file path"))
         .arg(Arg::new("graphql").long("graphql").value_name("URL").help("GraphQL endpoint URL"))
-        .arg(Arg::new("auth-header").long("auth-header").value_name("NAME:VALUE").action(ArgAction::Append).help("Auth header (repeatable)"))
+        .arg(Arg::new("auth-header").long("auth-header").value_name("NAME:VALUE").action(ArgAction::Append).help("Auth header with secret resolution (repeatable)"))
+        .arg(Arg::new("header").long("header").value_name("KEY:VALUE").action(ArgAction::Append).help("Arbitrary HTTP header (repeatable)"))
+        .arg(Arg::new("base-url").long("base-url").value_name("URL").help("Override base URL for OpenAPI spec"))
         .arg(Arg::new("pretty").long("pretty").action(ArgAction::SetTrue).help("Pretty-print JSON output"))
         .arg(Arg::new("raw").long("raw").action(ArgAction::SetTrue).help("Print raw string values"))
         .arg(Arg::new("refresh").long("refresh").action(ArgAction::SetTrue).help("Bypass cache, re-fetch"))

--- a/src/openapi_gen.rs
+++ b/src/openapi_gen.rs
@@ -65,10 +65,14 @@ fn build_post_operation(cmd: &CommandDef) -> serde_json::Value {
     let mut required_fields: Vec<serde_json::Value> = vec![];
 
     for p in &cmd.params {
-        properties.insert(p.name.clone(), serde_json::json!({
-            "description": p.description,
-            "schema": p.schema,
-        }));
+        let mut prop = serde_json::Map::new();
+        prop.insert("description".to_string(), serde_json::Value::String(p.description.clone()));
+        if let serde_json::Value::Object(schema_fields) = &p.schema {
+            for (k, v) in schema_fields {
+                prop.insert(k.clone(), v.clone());
+            }
+        }
+        properties.insert(p.name.clone(), serde_json::Value::Object(prop));
         if p.required {
             required_fields.push(serde_json::Value::String(p.name.clone()));
         }
@@ -170,7 +174,10 @@ mod tests {
         let path = &doc["paths"]["/todo-add"];
         assert!(path["post"].is_object(), "todo-add (has required param) should be POST");
         let body = &path["post"]["requestBody"]["content"]["application/json"]["schema"];
-        assert!(body["properties"]["content"].is_object());
+        assert_eq!(body["properties"]["content"]["type"], "string");
+        assert!(body["properties"]["content"]["description"].is_string());
+        // Must NOT have a nested "schema" key:
+        assert!(body["properties"]["content"].get("schema").is_none());
     }
 
     #[test]

--- a/src/openapi_gen.rs
+++ b/src/openapi_gen.rs
@@ -1,0 +1,182 @@
+use crate::domain::CommandDef;
+
+/// Generate an OpenAPI 3.1 document from a list of CommandDefs.
+/// Commands with any required param → POST (request body).
+/// Commands with only optional params → GET (query params).
+pub fn generate(tool_name: &str, version: &str, commands: &[CommandDef]) -> serde_json::Value {
+    let mut paths = serde_json::Map::new();
+
+    for cmd in commands {
+        let has_required = cmd.params.iter().any(|p| p.required);
+        let path_key = format!("/{}", cmd.name);
+
+        let operation = if has_required {
+            build_post_operation(cmd)
+        } else {
+            build_get_operation(cmd)
+        };
+
+        let method = if has_required { "post" } else { "get" };
+        let mut path_item = serde_json::Map::new();
+        path_item.insert(method.to_string(), operation);
+        paths.insert(path_key, serde_json::Value::Object(path_item));
+    }
+
+    serde_json::json!({
+        "openapi": "3.1.0",
+        "info": {
+            "title": tool_name,
+            "version": version,
+        },
+        "paths": paths,
+    })
+}
+
+fn build_get_operation(cmd: &CommandDef) -> serde_json::Value {
+    let parameters: Vec<serde_json::Value> = cmd.params.iter().map(|p| {
+        serde_json::json!({
+            "name": p.name,
+            "in": "query",
+            "required": p.required,
+            "description": p.description,
+            "schema": p.schema,
+        })
+    }).collect();
+
+    serde_json::json!({
+        "summary": cmd.description,
+        "operationId": cmd.name,
+        "parameters": parameters,
+        "responses": {
+            "200": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": { "type": "object", "additionalProperties": true }
+                    }
+                }
+            }
+        }
+    })
+}
+
+fn build_post_operation(cmd: &CommandDef) -> serde_json::Value {
+    let mut properties = serde_json::Map::new();
+    let mut required_fields: Vec<serde_json::Value> = vec![];
+
+    for p in &cmd.params {
+        properties.insert(p.name.clone(), serde_json::json!({
+            "description": p.description,
+            "schema": p.schema,
+        }));
+        if p.required {
+            required_fields.push(serde_json::Value::String(p.name.clone()));
+        }
+    }
+
+    let body_schema = if required_fields.is_empty() {
+        serde_json::json!({ "type": "object", "properties": properties })
+    } else {
+        serde_json::json!({ "type": "object", "properties": properties, "required": required_fields })
+    };
+
+    serde_json::json!({
+        "summary": cmd.description,
+        "operationId": cmd.name,
+        "requestBody": {
+            "required": true,
+            "content": {
+                "application/json": { "schema": body_schema }
+            }
+        },
+        "responses": {
+            "200": {
+                "description": "Success",
+                "content": {
+                    "application/json": {
+                        "schema": { "type": "object", "additionalProperties": true }
+                    }
+                }
+            }
+        }
+    })
+}
+
+/// Serialize an OpenAPI document to YAML string.
+pub fn to_yaml(doc: &serde_json::Value) -> Result<String, serde_yaml::Error> {
+    serde_yaml::to_string(doc)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::{CommandDef, ParamDef, ParamLocation};
+
+    fn sample_commands() -> Vec<CommandDef> {
+        vec![
+            CommandDef {
+                name: "todo-list".to_string(),
+                description: "List todos".to_string(),
+                source_name: "doob".to_string(),
+                params: vec![
+                    ParamDef {
+                        name: "status".to_string(),
+                        original_name: "status".to_string(),
+                        required: false,
+                        description: "Filter by status".to_string(),
+                        location: ParamLocation::ToolInput,
+                        schema: serde_json::json!({"type": "string"}),
+                    },
+                ],
+            },
+            CommandDef {
+                name: "todo-add".to_string(),
+                description: "Add todos".to_string(),
+                source_name: "doob".to_string(),
+                params: vec![
+                    ParamDef {
+                        name: "content".to_string(),
+                        original_name: "content".to_string(),
+                        required: true,
+                        description: "Task description".to_string(),
+                        location: ParamLocation::ToolInput,
+                        schema: serde_json::json!({"type": "string"}),
+                    },
+                ],
+            },
+        ]
+    }
+
+    #[test]
+    fn generates_valid_openapi_document() {
+        let doc = generate("doob", "0.1.0", &sample_commands());
+        assert_eq!(doc["openapi"], "3.1.0");
+        assert_eq!(doc["info"]["title"], "doob");
+        assert!(doc["paths"].is_object());
+    }
+
+    #[test]
+    fn get_command_maps_to_get_path() {
+        let doc = generate("doob", "0.1.0", &sample_commands());
+        let path = &doc["paths"]["/todo-list"];
+        assert!(path["get"].is_object(), "todo-list should be GET");
+        let params = path["get"]["parameters"].as_array().unwrap();
+        assert!(params.iter().any(|p| p["name"] == "status"));
+    }
+
+    #[test]
+    fn post_command_maps_to_post_path() {
+        let doc = generate("doob", "0.1.0", &sample_commands());
+        let path = &doc["paths"]["/todo-add"];
+        assert!(path["post"].is_object(), "todo-add (has required param) should be POST");
+        let body = &path["post"]["requestBody"]["content"]["application/json"]["schema"];
+        assert!(body["properties"]["content"].is_object());
+    }
+
+    #[test]
+    fn yaml_output_is_valid() {
+        let doc = generate("doob", "0.1.0", &sample_commands());
+        let yaml = to_yaml(&doc).unwrap();
+        assert!(yaml.contains("openapi: 3.1.0"));
+    }
+}

--- a/src/scanner/claude_config.rs
+++ b/src/scanner/claude_config.rs
@@ -1,0 +1,127 @@
+use async_trait::async_trait;
+use std::collections::HashSet;
+
+use crate::discovery::{BackendKind, DiscoveredSource, SourceScanner};
+
+/// Scans Claude Code config files and project `.mcp.json` files for MCP server definitions.
+pub struct ClaudeConfigScanner {
+    settings_paths: Vec<String>,
+    mcp_paths: Vec<String>,
+}
+
+impl ClaudeConfigScanner {
+    pub fn from_paths(settings_paths: Vec<String>, mcp_paths: Vec<String>) -> Self {
+        Self { settings_paths, mcp_paths }
+    }
+
+    pub fn default_env() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        let claude_settings = home.join(".claude/settings.json");
+
+        let mut mcp_paths = vec![];
+        if let Ok(entries) = std::fs::read_dir(home.join("dev")) {
+            for entry in entries.flatten() {
+                let p = entry.path();
+                for name in &[".mcp.json", "mcp.json"] {
+                    let candidate = p.join(name);
+                    if candidate.exists() {
+                        mcp_paths.push(candidate.to_string_lossy().to_string());
+                    }
+                }
+                let cursor = p.join(".cursor/mcp.json");
+                if cursor.exists() {
+                    mcp_paths.push(cursor.to_string_lossy().to_string());
+                }
+            }
+        }
+
+        Self {
+            settings_paths: if claude_settings.exists() {
+                vec![claude_settings.to_string_lossy().to_string()]
+            } else {
+                vec![]
+            },
+            mcp_paths,
+        }
+    }
+
+    fn parse_server_entry(
+        name: &str,
+        entry: &serde_json::Value,
+        origin: &str,
+        seen: &mut HashSet<String>,
+    ) -> Option<DiscoveredSource> {
+        if let Some(url) = entry.get("url").and_then(|v| v.as_str()) {
+            let dedup_key = format!("http:{url}");
+            if !seen.insert(dedup_key) {
+                return None;
+            }
+            return Some(DiscoveredSource {
+                name: name.to_string(),
+                kind: BackendKind::McpHttp { url: url.to_string() },
+                origin: origin.to_string(),
+            });
+        }
+
+        let cmd = entry.get("command").and_then(|v| v.as_str())?;
+        let args: Vec<String> = entry
+            .get("args")
+            .and_then(|a| a.as_array())
+            .map(|arr| arr.iter().filter_map(|v| v.as_str()).map(String::from).collect())
+            .unwrap_or_default();
+        let command_str = if args.is_empty() {
+            cmd.to_string()
+        } else {
+            format!("{} {}", cmd, args.join(" "))
+        };
+
+        let dedup_key = format!("stdio:{command_str}");
+        if !seen.insert(dedup_key) {
+            return None;
+        }
+
+        Some(DiscoveredSource {
+            name: name.to_string(),
+            kind: BackendKind::McpStdio { command: command_str },
+            origin: origin.to_string(),
+        })
+    }
+
+    fn parse_file(path: &str, seen: &mut HashSet<String>) -> Vec<DiscoveredSource> {
+        let Ok(text) = std::fs::read_to_string(path) else { return vec![] };
+        let Ok(json): Result<serde_json::Value, _> = serde_json::from_str(&text) else {
+            return vec![];
+        };
+
+        let servers = json.get("mcpServers")
+            .and_then(|v| v.as_object())
+            .or_else(|| json.as_object());
+
+        let Some(servers) = servers else { return vec![] };
+
+        servers
+            .iter()
+            .filter_map(|(name, entry)| {
+                if !entry.is_object() { return None; }
+                Self::parse_server_entry(name, entry, path, seen)
+            })
+            .collect()
+    }
+}
+
+#[async_trait]
+impl SourceScanner for ClaudeConfigScanner {
+    async fn scan(&self) -> Vec<DiscoveredSource> {
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut sources = vec![];
+
+        for path in &self.settings_paths {
+            sources.extend(Self::parse_file(path, &mut seen));
+        }
+        for path in &self.mcp_paths {
+            sources.extend(Self::parse_file(path, &mut seen));
+        }
+
+        sources
+    }
+}

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,0 +1,3 @@
+pub mod claude_config;
+pub mod workspace;
+pub mod well_known;

--- a/src/scanner/well_known.rs
+++ b/src/scanner/well_known.rs
@@ -1,0 +1,18 @@
+// stub — implemented in Task 4
+use async_trait::async_trait;
+use crate::discovery::{DiscoveredSource, SourceScanner};
+
+pub struct WellKnownScanner;
+
+impl WellKnownScanner {
+    pub fn new() -> Self { Self }
+}
+
+impl Default for WellKnownScanner {
+    fn default() -> Self { Self::new() }
+}
+
+#[async_trait]
+impl SourceScanner for WellKnownScanner {
+    async fn scan(&self) -> Vec<DiscoveredSource> { vec![] }
+}

--- a/src/scanner/well_known.rs
+++ b/src/scanner/well_known.rs
@@ -1,7 +1,22 @@
-// stub — implemented in Task 4
 use async_trait::async_trait;
-use crate::discovery::{DiscoveredSource, SourceScanner};
 
+use crate::discovery::{BackendKind, DiscoveredSource, SourceScanner};
+
+enum WellKnownKind {
+    McpHttp(&'static str),
+}
+
+/// (name, health-check URL, kind)
+const WELL_KNOWN: &[(&str, &str, WellKnownKind)] = &[
+    (
+        "pieces-mcp",
+        "http://localhost:39300/.well-known/health",
+        WellKnownKind::McpHttp("http://localhost:39300/model_context_protocol/2024-11-05/sse"),
+    ),
+];
+
+/// Probes well-known local HTTP ports to detect running API servers.
+/// Each entry is checked with a GET health request; reachable ones are included.
 pub struct WellKnownScanner;
 
 impl WellKnownScanner {
@@ -14,5 +29,32 @@ impl Default for WellKnownScanner {
 
 #[async_trait]
 impl SourceScanner for WellKnownScanner {
-    async fn scan(&self) -> Vec<DiscoveredSource> { vec![] }
+    async fn scan(&self) -> Vec<DiscoveredSource> {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap_or_default();
+
+        let mut sources = vec![];
+
+        for (name, health_url, kind) in WELL_KNOWN {
+            let reachable = client.get(*health_url).send().await
+                .map(|r| r.status().is_success())
+                .unwrap_or(false);
+
+            if reachable {
+                let backend_kind = match kind {
+                    WellKnownKind::McpHttp(url) =>
+                        BackendKind::McpHttp { url: url.to_string() },
+                };
+                sources.push(DiscoveredSource {
+                    name: name.to_string(),
+                    kind: backend_kind,
+                    origin: "well-known probe".to_string(),
+                });
+            }
+        }
+
+        sources
+    }
 }

--- a/src/scanner/workspace.rs
+++ b/src/scanner/workspace.rs
@@ -1,17 +1,90 @@
-// stub — implemented in Task 3
 use async_trait::async_trait;
-use crate::discovery::{DiscoveredSource, SourceScanner};
+use std::path::Path;
 
+use crate::discovery::{BackendKind, DiscoveredSource, SourceScanner};
+
+const SKIP_DIRS: &[&str] = &["target", "node_modules", ".git", ".cache", "dist", "build"];
+const OPENAPI_FILENAMES: &[&str] = &[
+    "openapi.yaml", "openapi.yml", "openapi.json",
+    "swagger.yaml", "swagger.yml", "swagger.json",
+];
+
+/// Walks workspace root directories looking for OpenAPI spec files.
+/// Skips build artifact directories (target/, node_modules/, etc.).
 pub struct WorkspaceScanner {
-    pub roots: Vec<String>,
+    roots: Vec<String>,
 }
 
 impl WorkspaceScanner {
-    pub fn from_roots(roots: Vec<String>) -> Self { Self { roots } }
-    pub fn default_env() -> Self { Self { roots: vec![] } }
+    pub fn from_roots(roots: Vec<String>) -> Self {
+        Self { roots }
+    }
+
+    /// Default: scan ~/dev
+    pub fn default_env() -> Self {
+        let home = dirs::home_dir().unwrap_or_default();
+        Self::from_roots(vec![home.join("dev").to_string_lossy().to_string()])
+    }
+
+    fn is_openapi(path: &Path) -> bool {
+        let fname = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if !OPENAPI_FILENAMES.contains(&fname) {
+            return false;
+        }
+        let Ok(bytes) = std::fs::read(path) else { return false };
+        let snippet = String::from_utf8_lossy(&bytes[..bytes.len().min(512)]);
+        snippet.contains("openapi:") || snippet.contains(r#""openapi":"#)
+    }
+
+    fn walk(root: &Path, repo_name: &str) -> Vec<DiscoveredSource> {
+        let mut sources = vec![];
+        let Ok(entries) = std::fs::read_dir(root) else { return sources };
+
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                if SKIP_DIRS.contains(&name) {
+                    continue;
+                }
+                sources.extend(Self::walk(&path, repo_name));
+            } else if path.is_file() && Self::is_openapi(&path) {
+                let display = path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("openapi");
+                let name = format!("{repo_name}/{display}");
+
+                sources.push(DiscoveredSource {
+                    name,
+                    kind: BackendKind::OpenApiFile { path: path.to_string_lossy().to_string() },
+                    origin: root.to_string_lossy().to_string(),
+                });
+            }
+        }
+
+        sources
+    }
 }
 
 #[async_trait]
 impl SourceScanner for WorkspaceScanner {
-    async fn scan(&self) -> Vec<DiscoveredSource> { vec![] }
+    async fn scan(&self) -> Vec<DiscoveredSource> {
+        let mut sources = vec![];
+        for root in &self.roots {
+            let Ok(entries) = std::fs::read_dir(root) else { continue };
+            for entry in entries.flatten() {
+                let p = entry.path();
+                if p.is_dir() {
+                    let dir_name = p.file_name().and_then(|n| n.to_str()).unwrap_or("");
+                    if SKIP_DIRS.contains(&dir_name) {
+                        continue;
+                    }
+                    let repo_name = dir_name.to_string();
+                    sources.extend(Self::walk(&p, &repo_name));
+                }
+            }
+        }
+        sources
+    }
 }

--- a/src/scanner/workspace.rs
+++ b/src/scanner/workspace.rs
@@ -1,0 +1,17 @@
+// stub — implemented in Task 3
+use async_trait::async_trait;
+use crate::discovery::{DiscoveredSource, SourceScanner};
+
+pub struct WorkspaceScanner {
+    pub roots: Vec<String>,
+}
+
+impl WorkspaceScanner {
+    pub fn from_roots(roots: Vec<String>) -> Self { Self { roots } }
+    pub fn default_env() -> Self { Self { roots: vec![] } }
+}
+
+#[async_trait]
+impl SourceScanner for WorkspaceScanner {
+    async fn scan(&self) -> Vec<DiscoveredSource> { vec![] }
+}

--- a/tests/cli_backend.rs
+++ b/tests/cli_backend.rs
@@ -1,0 +1,24 @@
+#[cfg(feature = "integration")]
+mod tests {
+    #[tokio::test]
+    async fn mcpipe_cli_list_doob() {
+        use mcpipe::backend::cli::CliBackend;
+        use mcpipe::backend::Backend;
+        let backend = CliBackend::new("doob");
+        let cmds = backend.discover().await.unwrap();
+        assert!(cmds.iter().any(|c| c.name == "todo-list"));
+    }
+
+    #[tokio::test]
+    async fn gen_openapi_from_doob() {
+        use mcpipe::backend::cli::CliBackend;
+        use mcpipe::backend::Backend;
+        use mcpipe::openapi_gen;
+        let backend = CliBackend::new("doob");
+        let cmds = backend.discover().await.unwrap();
+        let doc = openapi_gen::generate("doob", "0.1.0", &cmds);
+        let yaml = openapi_gen::to_yaml(&doc).unwrap();
+        assert!(yaml.contains("openapi: 3.1.0"));
+        assert!(yaml.contains("/todo-list"));
+    }
+}

--- a/tests/fixtures/claude_settings.json
+++ b/tests/fixtures/claude_settings.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "devloop": {
+      "command": "/usr/local/bin/devloop",
+      "args": ["mcp-server"]
+    },
+    "personal-mcp": {
+      "command": "/usr/local/bin/personal-mcp",
+      "args": []
+    }
+  }
+}

--- a/tests/fixtures/mcp_project.json
+++ b/tests/fixtures/mcp_project.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "devloop-pipeline": {
+      "type": "stdio",
+      "command": "devloop",
+      "args": ["mcp-server"],
+      "env": {}
+    }
+  }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,0 +1,105 @@
+#![cfg(feature = "integration")]
+
+//! Integration tests — run with `cargo test --features integration`.
+//!
+//! These tests are excluded from the normal `cargo test` run so they don't
+//! block CI without the necessary external fixtures or environment.
+
+use mcpipe::backend::openapi::OpenApiBackend;
+use mcpipe::backend::Backend;
+use mcpipe::domain::ParamLocation;
+
+/// Smoke-test: discover commands from the bundled petstore fixture.
+///
+/// This is a fast, self-contained integration test that exercises the full
+/// OpenApiBackend pipeline (parse → normalise → discover) without any network
+/// calls or external processes.
+#[tokio::test]
+async fn integration_openapi_discover_petstore() {
+    let path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/petstore.json");
+    let backend = OpenApiBackend::from_file(path).expect("failed to load petstore fixture");
+    let cmds = backend.discover().await.expect("discover failed");
+
+    assert_eq!(cmds.len(), 3, "expected exactly 3 petstore commands");
+
+    let list = cmds.iter().find(|c| c.name == "list-pets").expect("list-pets missing");
+    assert_eq!(list.source_name, "listPets");
+    assert!(
+        list.params.iter().all(|p| matches!(p.location, ParamLocation::Query | ParamLocation::Path | ParamLocation::Header | ParamLocation::Body)),
+        "unexpected param location on list-pets"
+    );
+
+    let create = cmds.iter().find(|c| c.name == "create-pet").expect("create-pet missing");
+    let name_param = create.params.iter().find(|p| p.name == "name").expect("name param missing");
+    assert!(name_param.required, "name param should be required");
+    assert!(
+        matches!(name_param.location, ParamLocation::Body),
+        "name param should be in request body"
+    );
+
+    let show = cmds.iter().find(|c| c.name == "show-pet-by-id").expect("show-pet-by-id missing");
+    let id_param = show.params.iter().find(|p| p.name == "pet-id").expect("petId param missing");
+    assert!(id_param.required, "pet-id param should be required");
+    assert!(
+        matches!(id_param.location, ParamLocation::Path),
+        "pet-id param should be a path parameter"
+    );
+}
+
+/// Negative test: loading a backend from a non-existent file path should
+/// return an error rather than panic.
+#[tokio::test]
+async fn integration_openapi_missing_file_returns_error() {
+    let result = OpenApiBackend::from_file("/nonexistent/path/spec.json");
+    assert!(result.is_err(), "expected an error for missing spec file");
+}
+
+/// MCP stdio integration: discover tools from the bundled echo fixture.
+///
+/// Requires Python 3 on PATH.  Skipped automatically when `python3` is absent
+/// (the `which_python` helper panics with a clear message in that case).
+#[tokio::test]
+async fn integration_mcp_stdio_echo() {
+    let python = which_python();
+    let script = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/mcp_echo.py");
+    let cmd = format!("{python} {script}");
+
+    let backend = mcpipe::backend::mcp::McpBackend::from_stdio(cmd);
+    let cmds = backend.discover().await.expect("MCP stdio discover failed");
+
+    assert_eq!(cmds.len(), 1, "echo fixture should expose exactly one tool");
+    assert_eq!(cmds[0].name, "echo");
+    assert_eq!(cmds[0].params.len(), 1);
+    assert_eq!(cmds[0].params[0].name, "message");
+    assert!(cmds[0].params[0].required);
+
+    // Execute the tool and verify round-trip.
+    let mut args = std::collections::HashMap::new();
+    args.insert("message".to_string(), serde_json::json!("integration test"));
+
+    let result = backend
+        .execute(&cmds[0], args)
+        .await
+        .expect("MCP stdio execute failed");
+
+    let text = result
+        .get(0)
+        .and_then(|v| v.get("text"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| result.as_str().unwrap_or(""));
+    assert_eq!(text, "integration test");
+}
+
+fn which_python() -> String {
+    for candidate in &["python3", "python"] {
+        if std::process::Command::new(candidate)
+            .arg("--version")
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false)
+        {
+            return candidate.to_string();
+        }
+    }
+    panic!("python3 not found — required for MCP integration tests");
+}

--- a/tests/scanner_claude_config.rs
+++ b/tests/scanner_claude_config.rs
@@ -1,0 +1,12 @@
+use mcpipe::discovery::{BackendKind, DiscoveredSource};
+
+#[test]
+fn discovered_source_roundtrip() {
+    let src = DiscoveredSource {
+        name: "my-server".to_string(),
+        kind: BackendKind::McpStdio { command: "my-server mcp".to_string() },
+        origin: "~/.claude/settings.json".to_string(),
+    };
+    assert_eq!(src.name, "my-server");
+    assert!(matches!(src.kind, BackendKind::McpStdio { .. }));
+}

--- a/tests/scanner_claude_config.rs
+++ b/tests/scanner_claude_config.rs
@@ -1,4 +1,6 @@
 use mcpipe::discovery::{BackendKind, DiscoveredSource};
+use mcpipe::scanner::claude_config::ClaudeConfigScanner;
+use mcpipe::discovery::SourceScanner;
 
 #[test]
 fn discovered_source_roundtrip() {
@@ -9,4 +11,60 @@ fn discovered_source_roundtrip() {
     };
     assert_eq!(src.name, "my-server");
     assert!(matches!(src.kind, BackendKind::McpStdio { .. }));
+}
+
+#[tokio::test]
+async fn scans_settings_json_mcp_servers() {
+    let settings_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/claude_settings.json"
+    );
+    let scanner = ClaudeConfigScanner::from_paths(
+        vec![settings_path.to_string()],
+        vec![],
+    );
+    let sources = scanner.scan().await;
+    assert_eq!(sources.len(), 2);
+    let names: Vec<_> = sources.iter().map(|s| s.name.as_str()).collect();
+    assert!(names.contains(&"devloop"));
+    assert!(names.contains(&"personal-mcp"));
+    for src in &sources {
+        assert!(matches!(src.kind, BackendKind::McpStdio { .. }));
+        assert_eq!(src.origin, settings_path);
+    }
+}
+
+#[tokio::test]
+async fn scans_project_mcp_json() {
+    let mcp_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/mcp_project.json"
+    );
+    let scanner = ClaudeConfigScanner::from_paths(
+        vec![],
+        vec![mcp_path.to_string()],
+    );
+    let sources = scanner.scan().await;
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].name, "devloop-pipeline");
+    assert!(matches!(sources[0].kind, BackendKind::McpStdio { .. }));
+}
+
+#[tokio::test]
+async fn deduplicates_same_command() {
+    let settings_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/claude_settings.json"
+    );
+    let mcp_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/mcp_project.json"
+    );
+    let scanner = ClaudeConfigScanner::from_paths(
+        vec![settings_path.to_string()],
+        vec![mcp_path.to_string()],
+    );
+    let sources = scanner.scan().await;
+    // settings has devloop + personal-mcp; project has devloop-pipeline (different command)
+    assert_eq!(sources.len(), 3);
 }

--- a/tests/scanner_workspace.rs
+++ b/tests/scanner_workspace.rs
@@ -1,0 +1,53 @@
+use mcpipe::scanner::workspace::WorkspaceScanner;
+use mcpipe::discovery::{BackendKind, SourceScanner};
+use tempfile::TempDir;
+use std::fs;
+
+#[tokio::test]
+async fn finds_openapi_yaml_in_workspace() {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path().join("myrepo");
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(repo.join("openapi.yaml"), r#"
+openapi: "3.0.0"
+info:
+  title: Test API
+  version: "1.0"
+paths: {}
+"#).unwrap();
+
+    let scanner = WorkspaceScanner::from_roots(vec![dir.path().to_string_lossy().to_string()]);
+    let sources = scanner.scan().await;
+
+    assert_eq!(sources.len(), 1);
+    assert!(matches!(sources[0].kind, BackendKind::OpenApiFile { .. }));
+    assert!(sources[0].name.contains("myrepo"));
+}
+
+#[tokio::test]
+async fn ignores_non_openapi_yaml() {
+    let dir = TempDir::new().unwrap();
+    let repo = dir.path().join("myrepo");
+    fs::create_dir_all(&repo).unwrap();
+    fs::write(repo.join("random.yaml"), "key: value\n").unwrap();
+
+    let scanner = WorkspaceScanner::from_roots(vec![dir.path().to_string_lossy().to_string()]);
+    let sources = scanner.scan().await;
+    assert!(sources.is_empty());
+}
+
+#[tokio::test]
+async fn skips_target_and_node_modules() {
+    let dir = TempDir::new().unwrap();
+    let target = dir.path().join("myrepo/target/debug");
+    fs::create_dir_all(&target).unwrap();
+    fs::write(target.join("openapi.yaml"), "openapi: \"3.0.0\"\npaths: {}\n").unwrap();
+
+    let node = dir.path().join("myrepo/node_modules/pkg");
+    fs::create_dir_all(&node).unwrap();
+    fs::write(node.join("openapi.json"), r#"{"openapi":"3.0.0","paths":{}}"#).unwrap();
+
+    let scanner = WorkspaceScanner::from_roots(vec![dir.path().to_string_lossy().to_string()]);
+    let sources = scanner.scan().await;
+    assert!(sources.is_empty(), "should skip target/ and node_modules/");
+}


### PR DESCRIPTION
## Summary

- Adds `CliBackend` — a new `Backend` implementation that discovers commands by running
  `<tool> schema --json` and dispatches execution as subprocesses
- Adds `openapi_gen` module — generates OpenAPI 3.1 specs from any `Vec<CommandDef>`,
  routing commands with required params to POST and optional-only to GET
- Wires `--cli <COMMAND>`, `--gen-openapi`, and `--openapi-output <FILE>` flags to main CLI
- Adds `BackendKind::Cli` variant to `DiscoveredSource`

Usage:
```
mcpipe --cli doob --list
mcpipe --cli doob --gen-openapi
mcpipe --cli doob --gen-openapi --openapi-output doob.openapi.yaml
```

## Test Plan
- [ ] `cargo test` — 40 unit tests pass
- [ ] `cargo test --features integration` — integration tests against live `doob` binary pass
- [ ] Smoke test: `mcpipe --cli doob --list` lists 15 doob commands
- [ ] Smoke test: `mcpipe --cli doob --gen-openapi` prints valid OpenAPI 3.1 YAML
- [ ] `--gen-openapi` without `--cli` returns an error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CLI backend discovery and execution for external command-line tools
  * Introduced multi-source scanning system to discover MCP servers and OpenAPI specs from Claude config, workspace directories, and well-known endpoints
  * Added OpenAPI generation from CLI tools
  * Enhanced header support with new `--header` flag and base URL override via `--base-url`
  * Added `--scan` functionality to catalog all available tools across configured sources
  * Added per-command GraphQL field selection override via `--fields`

* **Documentation**
  * Added build/run guide and architecture documentation

* **Tests**
  * Added integration tests for CLI backends, OpenAPI discovery, and MCP stdio
  * Added scanner tests for Claude config and workspace discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->